### PR TITLE
Fix Linux input events on 32-bit systems (Raspberry Pi)

### DIFF
--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/Linux.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/Linux.java
@@ -32,7 +32,16 @@ class Linux {
   final static String HANDLE_READ = "read";
   final static String HANDLE_SELECT = "select";
 
-  private final static int EVIOCGVERSION = _IOR('E', 0x01, JAVA_INT.byteSize());
+  private static final boolean IS_32_BIT = is32BitSystem();
+
+  private static boolean is32BitSystem() {
+    String osArch = System.getProperty("os.arch", "").toLowerCase();
+    return osArch.equals("arm") || osArch.equals("i386") || osArch.equals("i486")
+        || osArch.equals("i586") || osArch.equals("i686") || osArch.equals("x86")
+        || osArch.startsWith("armv");
+  }
+
+  private static int EVIOCGVERSION = _IOR('E', 0x01, JAVA_INT.byteSize());
   private final static int EVIOCGID = _IOR('E', 0x02, input_id.$LAYOUT.byteSize());
   private final static int EVIOCGNAME = _IOC(_IOC_READ, 'E', 0x06, NAME_BUFFER_SIZE);
   private static final int EVIOCGEFFECTS = _IOR('E', 0x84, JAVA_INT.byteSize());
@@ -59,11 +68,13 @@ class Linux {
     errnoHandle = capturedStateLayout.varHandle(MemoryLayout.PathElement.groupElement(ERRNO));
     strerror = downcallHandle(HANDLE_STRERROR, FunctionDescriptor.of(ADDRESS, JAVA_INT));
 
+    ValueLayout sizeT = IS_32_BIT ? JAVA_INT : JAVA_LONG;
+
     handles.put(HANDLE_OPEN, downcallHandle(HANDLE_OPEN, FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT), ERRNO));
     handles.put(HANDLE_CLOSE, downcallHandle(HANDLE_CLOSE, FunctionDescriptor.of(JAVA_INT, JAVA_INT), ERRNO));
     handles.put(HANDLE_IOCTL, downcallHandle(HANDLE_IOCTL, FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT, ADDRESS), ERRNO));
-    handles.put(HANDLE_READ, downcallHandle(HANDLE_READ, FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS, JAVA_LONG), ERRNO));
-    handles.put(HANDLE_SELECT, downcallHandle(HANDLE_SELECT, FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS, ADDRESS, ADDRESS, JAVA_LONG), ERRNO));
+    handles.put(HANDLE_READ, downcallHandle(HANDLE_READ, FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS, sizeT), ERRNO));
+    handles.put(HANDLE_SELECT, downcallHandle(HANDLE_SELECT, FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS, ADDRESS, ADDRESS, sizeT), ERRNO));
   }
 
   /**

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/timeval.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/timeval.java
@@ -5,6 +5,7 @@ import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.invoke.VarHandle;
 
+import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 
 class timeval {
@@ -18,9 +19,18 @@ class timeval {
    */
   public long tv_usec;
 
+  private static final boolean IS_32_BIT = is32BitSystem();
+
+  private static boolean is32BitSystem() {
+    String osArch = System.getProperty("os.arch", "").toLowerCase();
+    return osArch.equals("arm") || osArch.equals("i386") || osArch.equals("i486")
+        || osArch.equals("i586") || osArch.equals("i686") || osArch.equals("x86")
+        || osArch.startsWith("armv");
+  }
+
   static final GroupLayout $LAYOUT = MemoryLayout.structLayout(
-          JAVA_LONG.withName("tv_sec"),
-          JAVA_LONG.withName("tv_usec")
+          (IS_32_BIT ? JAVA_INT : JAVA_LONG).withName("tv_sec"),
+          (IS_32_BIT ? JAVA_INT : JAVA_LONG).withName("tv_usec")
   ).withName("timeval");
 
   static final VarHandle VH_tv_sec = $LAYOUT.varHandle(MemoryLayout.PathElement.groupElement("tv_sec"));

--- a/src/test/java/de/gurkenlabs/input4j/foreign/linux/LinuxDataStructTests.java
+++ b/src/test/java/de/gurkenlabs/input4j/foreign/linux/LinuxDataStructTests.java
@@ -122,4 +122,20 @@ public class LinuxDataStructTests {
       assertEquals(t.tv_usec, timevalFromMemory.tv_usec);
     }
   }
+
+  @Test
+  @EnabledOnOs(OS.LINUX)
+  void testTimevalLayoutSize() {
+    String osArch = System.getProperty("os.arch", "").toLowerCase();
+    boolean is32Bit = osArch.equals("arm") || osArch.equals("i386") || osArch.equals("i486")
+        || osArch.equals("i586") || osArch.equals("i686") || osArch.equals("x86")
+        || osArch.startsWith("armv");
+
+    long expectedSize = is32Bit ? 8 : 16;
+    assertEquals(expectedSize, timeval.$LAYOUT.byteSize(),
+        "timeval should be " + expectedSize + " bytes on " + osArch);
+
+    assertEquals(expectedSize, input_event.$LAYOUT.byteSize(),
+        "input_event should be " + expectedSize + "+8 bytes on " + osArch);
+  }
 }


### PR DESCRIPTION
Fixes #11

- Add architecture detection for 32-bit vs 64-bit Linux
- Fix timeval struct layout (8 bytes on 32-bit, 16 bytes on 64-bit)
- Fix read() and select() function descriptors for size_t parameter
- Add test to verify correct layout sizes