### PR TITLE
Add Javadoc to public classes and methods

### DIFF
--- a/src/main/java/de/gurkenlabs/input4j/AbstractInputDevicePlugin.java
+++ b/src/main/java/de/gurkenlabs/input4j/AbstractInputDevicePlugin.java
@@ -5,7 +5,12 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 
+/**
+ * Base class for input device plugins that provides common functionality for device management,
+ * hot-plugging support, and event handling.
+ */
 public abstract class AbstractInputDevicePlugin implements InputDevicePlugin {
+  /** Logger for the plugin package. */
   protected static final Logger log = Logger.getLogger(AbstractInputDevicePlugin.class.getPackage().getName());
   private final Collection<Consumer<InputDevice>> deviceConnectedListeners = ConcurrentHashMap.newKeySet();
   private final Collection<Consumer<InputDevice>> deviceDisconnectedListeners = ConcurrentHashMap.newKeySet();
@@ -15,6 +20,9 @@ public abstract class AbstractInputDevicePlugin implements InputDevicePlugin {
   private long lastDeviceUpdate;
   private Collection<InputDevice> devices;
 
+  /**
+   * Initializes the plugin with the hot-plug interval from the configuration.
+   */
   protected AbstractInputDevicePlugin() {
     this.hotPlugInterval = InputDevices.configure().getHotPlugInterval();
   }
@@ -115,6 +123,11 @@ public abstract class AbstractInputDevicePlugin implements InputDevicePlugin {
     this.setDevices(refreshedDevices);
   }
 
+  /**
+   * Refreshes the list of input devices by querying the underlying native API.
+   *
+   * @return A collection of currently available input devices.
+   */
   protected abstract Collection<InputDevice> refreshInputDevices();
   
   public void onDevicesChanged(Runnable listener) {

--- a/src/main/java/de/gurkenlabs/input4j/ComponentType.java
+++ b/src/main/java/de/gurkenlabs/input4j/ComponentType.java
@@ -8,9 +8,13 @@ package de.gurkenlabs.input4j;
  * </p>
  */
 public enum ComponentType {
+  /** Analog axis (e.g., joystick, trigger). */
   AXIS,
+  /** Digital button. */
   BUTTON,
+  /** Keyboard key. */
   KEY,
+  /** Unknown or unsupported component type. */
   UNKNOWN;
 
   /**

--- a/src/main/java/de/gurkenlabs/input4j/InputComponent.java
+++ b/src/main/java/de/gurkenlabs/input4j/InputComponent.java
@@ -33,6 +33,7 @@ public final class InputComponent {
    * Creates a new instance of the InputComponent class.
    *
    * @param device   the input device associated with this component
+   * @param id       the id of the component
    * @param relative true if the component provides relative input, false otherwise
    */
   public InputComponent(InputDevice device, ID id, boolean relative) {
@@ -54,6 +55,7 @@ public final class InputComponent {
    * Creates a new instance of the InputComponent class.
    *
    * @param device       the input device associated with this component
+   * @param id          the id of the component
    * @param originalName the name of the component
    * @param relative     true if the component provides relative input, false otherwise
    */
@@ -83,6 +85,11 @@ public final class InputComponent {
     return this.getId().type;
   }
 
+  /**
+   * Gets the component identifier.
+   *
+   * @return the component identifier
+   */
   public ID getId() {
     return id;
   }
@@ -174,45 +181,80 @@ public final class InputComponent {
    * public static final DualShock4 SQUARE = new DualShock4(InputComponent.Button.get(0), "SQUARE");
    * }</pre>
    */
+  /**
+   * Identifier for an input component.
+   */
   public static class ID {
+    /** Component ID number. */
     public final int id;
+    /** Native platform-specific ID. */
     public final int nativeId;
+    /** Component type (axis, button, key). */
     public final ComponentType type;
+    /** Human-readable name. */
     public String name;
 
     private static final List<ID> ids = new CopyOnWriteArrayList<>();
 
     /**
-     * If you want to make this ID accessible with a different field, you can use this constructor.
+     * Creates a new ID by copying another ID.
      *
-     * @param otherId the ID to remap
+     * @param otherId the ID to copy
      */
     public ID(ID otherId) {
       this(otherId.type, otherId.id, otherId.name, 0);
     }
 
+    /**
+     * Creates a new ID by copying another ID with a native ID.
+     *
+     * @param otherId  the ID to copy
+     * @param nativeId the native platform-specific ID
+     */
     public ID(ID otherId, int nativeId) {
       this(otherId.type, otherId.id, otherId.name, nativeId);
     }
 
+    /**
+     * Creates a new ID by copying another ID with a custom name.
+     *
+     * @param otherId the ID to copy
+     * @param name    the custom name
+     */
     public ID(ID otherId, String name) {
       this(otherId.type, otherId.id, name, 0);
     }
 
     /**
-     * If you want to make this ID available with a different name, you can use this constructor.
+     * Creates a new ID by copying another ID with a custom name and native ID.
      *
-     * @param otherId the ID to remap
-     * @param name    the name of the new ID
+     * @param otherId  the ID to copy
+     * @param name     the custom name
+     * @param nativeId the native platform-specific ID
      */
     public ID(ID otherId, String name, int nativeId) {
       this(otherId.type, otherId.id, name, nativeId);
     }
 
+    /**
+     * Creates a new ID with the given type, id, and name.
+     *
+     * @param type the component type
+     * @param id   the component ID
+     * @param name the component name
+     */
     public ID(ComponentType type, int id, String name) {
       this(type, id, name, 0);
     }
 
+    /**
+     * Creates a new ID with the given type, id, name, and native ID.
+     *
+     * @param type     the component type
+     * @param id       the component ID
+     * @param name     the component name
+     * @param nativeId the native platform-specific ID
+     */
     public ID(ComponentType type, int id, String name, int nativeId) {
       this.type = type;
       this.id = id;
@@ -242,31 +284,72 @@ public final class InputComponent {
       return this.name;
     }
 
+    /**
+     * Gets the next available axis ID.
+     *
+     * @return the next available axis ID
+     */
     public static int getNextAxisId() {
       return getNextId(ComponentType.AXIS, Axis.MAX_DEFAULT_AXIS_ID);
     }
 
+    /**
+     * Gets the next available button ID.
+     *
+     * @return the next available button ID
+     */
     public static int getNextButtonId() {
       return getNextId(ComponentType.BUTTON, Button.MAX_DEFAULT_BUTTON_ID);
     }
 
+    /**
+     * Gets the next available ID for a given component type.
+     *
+     * @param type  the component type
+     * @param minId the minimum ID to reserve for default components
+     * @return the next available ID
+     */
     public static int getNextId(ComponentType type, int minId) {
       // reserve the id range for the default buttons and axes
       return Math.max(ids.stream().filter(i -> i.type == type).mapToInt(i -> i.id).max().orElse(0), minId) + 1;
     }
 
+    /**
+     * Gets all registered component IDs.
+     *
+     * @return list of all IDs
+     */
     public static List<ID> getAll() {
       return ids;
     }
 
+    /**
+     * Gets a component ID by type and numeric ID.
+     *
+     * @param type the component type
+     * @param id   the numeric ID
+     * @return the matching ID or null
+     */
     public static ID get(ComponentType type, int id){
       return ids.stream().filter(i -> i.type == type && i.id == id).findFirst().orElse(null);
     }
 
+    /**
+     * Gets a button ID by numeric ID.
+     *
+     * @param id the button numeric ID
+     * @return the matching button ID or null
+     */
     public static ID getButton(int id) {
       return ids.stream().filter(i -> i.type.isButton() && i.id == id).findFirst().orElse(null);
     }
 
+    /**
+     * Gets an axis ID by numeric ID.
+     *
+     * @param id the axis numeric ID
+     * @return the matching axis ID or null
+     */
     public static ID getAxis(int id) {
       return ids.stream().filter(i -> i.type.isAxis() && i.id == id).findFirst().orElse(null);
     }

--- a/src/main/java/de/gurkenlabs/input4j/InputDevice.java
+++ b/src/main/java/de/gurkenlabs/input4j/InputDevice.java
@@ -240,6 +240,11 @@ public final class InputDevice implements Closeable {
     this.rumbleCallback.accept(this, intensity);
   }
 
+  /**
+   * Sets the accuracy for component value changes.
+   *
+   * @param decimalPlaces the number of decimal places to round to
+   */
   public void setAccuracy(int decimalPlaces) {
     if (decimalPlaces < 0) {
       throw new IllegalArgumentException("Decimal places must be a non-negative integer.");

--- a/src/main/java/de/gurkenlabs/input4j/components/Axis.java
+++ b/src/main/java/de/gurkenlabs/input4j/components/Axis.java
@@ -3,14 +3,26 @@ package de.gurkenlabs.input4j.components;
 import de.gurkenlabs.input4j.ComponentType;
 import de.gurkenlabs.input4j.InputComponent;
 
+/**
+ * Predefined axis component identifiers for standard gamepad controllers.
+ */
 public class Axis {
+  /** Maximum default axis ID value. */
   public static final int MAX_DEFAULT_AXIS_ID = 7;
+  /** Left stick X-axis (horizontal). */
   public static final InputComponent.ID AXIS_X = new InputComponent.ID(ComponentType.AXIS, 0, "LEFT_AXIS_X", 0);
+  /** Left stick Y-axis (vertical). */
   public static final InputComponent.ID AXIS_Y = new InputComponent.ID(ComponentType.AXIS, 1, "LEFT_AXIS_Y", 0);
+  /** Left stick Z-axis (typically left trigger). */
   public static final InputComponent.ID AXIS_Z = new InputComponent.ID(ComponentType.AXIS, 2, "LEFT_AXIS_Z", 0);
+  /** Right stick X-axis (horizontal). */
   public static final InputComponent.ID AXIS_RX = new InputComponent.ID(ComponentType.AXIS, 3, "RIGHT_AXIS_X", 0);
+  /** Right stick Y-axis (vertical). */
   public static final InputComponent.ID AXIS_RY = new InputComponent.ID(ComponentType.AXIS, 4, "RIGHT_AXIS_Y", 0);
+  /** Right stick Z-axis (typically right trigger). */
   public static final InputComponent.ID AXIS_RZ = new InputComponent.ID(ComponentType.AXIS, 5, "RIGHT_AXIS_Z", 0);
+  /** Slider axis. */
   public static final InputComponent.ID AXIS_SLIDER = new InputComponent.ID(ComponentType.AXIS, 6, "SLIDER", 0);
+  /** D-pad as axis (for analog d-pads). */
   public static final InputComponent.ID AXIS_DPAD = new InputComponent.ID(ComponentType.AXIS, MAX_DEFAULT_AXIS_ID, "DPAD_AXIS", 0);
 }

--- a/src/main/java/de/gurkenlabs/input4j/components/Button.java
+++ b/src/main/java/de/gurkenlabs/input4j/components/Button.java
@@ -3,42 +3,82 @@ package de.gurkenlabs.input4j.components;
 import de.gurkenlabs.input4j.ComponentType;
 import de.gurkenlabs.input4j.InputComponent;
 
+/**
+ * Predefined button component identifiers for standard gamepad controllers.
+ */
 public final class Button {
+  /** Maximum default button ID value. */
   public static int MAX_DEFAULT_BUTTON_ID = 35;
+  /** Button 0. */
   public static final InputComponent.ID BUTTON_0 = new InputComponent.ID(ComponentType.BUTTON, 0, "BUTTON_0", 0);
+  /** Button 1. */
   public static final InputComponent.ID BUTTON_1 = new InputComponent.ID(ComponentType.BUTTON, 1, "BUTTON_1", 0);
+  /** Button 2. */
   public static final InputComponent.ID BUTTON_2 = new InputComponent.ID(ComponentType.BUTTON, 2, "BUTTON_2", 0);
+  /** Button 3. */
   public static final InputComponent.ID BUTTON_3 = new InputComponent.ID(ComponentType.BUTTON, 3, "BUTTON_3", 0);
+  /** Button 4 (L1). */
   public static final InputComponent.ID BUTTON_4 = new InputComponent.ID(ComponentType.BUTTON, 4, "BUTTON_4", 0);
+  /** Button 5 (R1). */
   public static final InputComponent.ID BUTTON_5 = new InputComponent.ID(ComponentType.BUTTON, 5, "BUTTON_5", 0);
+  /** Button 6 (L2). */
   public static final InputComponent.ID BUTTON_6 = new InputComponent.ID(ComponentType.BUTTON, 6, "BUTTON_6", 0);
+  /** Button 7 (R2). */
   public static final InputComponent.ID BUTTON_7 = new InputComponent.ID(ComponentType.BUTTON, 7, "BUTTON_7", 0);
+  /** Button 8 (Share). */
   public static final InputComponent.ID BUTTON_8 = new InputComponent.ID(ComponentType.BUTTON, 8, "BUTTON_8", 0);
+  /** Button 9 (Options). */
   public static final InputComponent.ID BUTTON_9 = new InputComponent.ID(ComponentType.BUTTON, 9, "BUTTON_9", 0);
+  /** Button 10 (L3 - left stick press). */
   public static final InputComponent.ID BUTTON_10 = new InputComponent.ID(ComponentType.BUTTON, 10, "BUTTON_10", 0);
+  /** Button 11 (R3 - right stick press). */
   public static final InputComponent.ID BUTTON_11 = new InputComponent.ID(ComponentType.BUTTON, 11, "BUTTON_11", 0);
+  /** Button 12 (PS button). */
   public static final InputComponent.ID BUTTON_12 = new InputComponent.ID(ComponentType.BUTTON, 12, "BUTTON_12", 0);
+  /** Button 13 (Touchpad). */
   public static final InputComponent.ID BUTTON_13 = new InputComponent.ID(ComponentType.BUTTON, 13, "BUTTON_13", 0);
+  /** Button 14. */
   public static final InputComponent.ID BUTTON_14 = new InputComponent.ID(ComponentType.BUTTON, 14, "BUTTON_14", 0);
+  /** Button 15. */
   public static final InputComponent.ID BUTTON_15 = new InputComponent.ID(ComponentType.BUTTON, 15, "BUTTON_15", 0);
+  /** Button 16. */
   public static final InputComponent.ID BUTTON_16 = new InputComponent.ID(ComponentType.BUTTON, 16, "BUTTON_16", 0);
+  /** Button 17. */
   public static final InputComponent.ID BUTTON_17 = new InputComponent.ID(ComponentType.BUTTON, 17, "BUTTON_17", 0);
+  /** Button 18. */
   public static final InputComponent.ID BUTTON_18 = new InputComponent.ID(ComponentType.BUTTON, 18, "BUTTON_18", 0);
+  /** Button 19. */
   public static final InputComponent.ID BUTTON_19 = new InputComponent.ID(ComponentType.BUTTON, 19, "BUTTON_19", 0);
+  /** Button 20. */
   public static final InputComponent.ID BUTTON_20 = new InputComponent.ID(ComponentType.BUTTON, 20, "BUTTON_20", 0);
+  /** Button 21. */
   public static final InputComponent.ID BUTTON_21 = new InputComponent.ID(ComponentType.BUTTON, 21, "BUTTON_21", 0);
+  /** Button 22. */
   public static final InputComponent.ID BUTTON_22 = new InputComponent.ID(ComponentType.BUTTON, 22, "BUTTON_22", 0);
+  /** Button 23. */
   public static final InputComponent.ID BUTTON_23 = new InputComponent.ID(ComponentType.BUTTON, 23, "BUTTON_23", 0);
+  /** Button 24. */
   public static final InputComponent.ID BUTTON_24 = new InputComponent.ID(ComponentType.BUTTON, 24, "BUTTON_24", 0);
+  /** Button 25. */
   public static final InputComponent.ID BUTTON_25 = new InputComponent.ID(ComponentType.BUTTON, 25, "BUTTON_25", 0);
+  /** Button 26. */
   public static final InputComponent.ID BUTTON_26 = new InputComponent.ID(ComponentType.BUTTON, 26, "BUTTON_26", 0);
+  /** Button 27. */
   public static final InputComponent.ID BUTTON_27 = new InputComponent.ID(ComponentType.BUTTON, 27, "BUTTON_27", 0);
+  /** Button 28. */
   public static final InputComponent.ID BUTTON_28 = new InputComponent.ID(ComponentType.BUTTON, 28, "BUTTON_28", 0);
+  /** Button 29. */
   public static final InputComponent.ID BUTTON_29 = new InputComponent.ID(ComponentType.BUTTON, 29, "BUTTON_29", 0);
+  /** Button 30. */
   public static final InputComponent.ID BUTTON_30 = new InputComponent.ID(ComponentType.BUTTON, 30, "BUTTON_30", 0);
+  /** Button 31. */
   public static final InputComponent.ID BUTTON_31 = new InputComponent.ID(ComponentType.BUTTON, 31, "BUTTON_31", 0);
+  /** D-pad up. */
   public static final InputComponent.ID DPAD_UP = new InputComponent.ID(ComponentType.BUTTON, 32, "DPAD_UP", 0);
+  /** D-pad right. */
   public static final InputComponent.ID DPAD_RIGHT = new InputComponent.ID(ComponentType.BUTTON, 33, "DPAD_RIGHT", 0);
+  /** D-pad down. */
   public static final InputComponent.ID DPAD_DOWN = new InputComponent.ID(ComponentType.BUTTON, 34, "DPAD_DOWN", 0);
+  /** D-pad left. */
   public static final InputComponent.ID DPAD_LEFT = new InputComponent.ID(ComponentType.BUTTON, MAX_DEFAULT_BUTTON_ID, "DPAD_LEFT", 0);
 }

--- a/src/main/java/de/gurkenlabs/input4j/components/DualShock4.java
+++ b/src/main/java/de/gurkenlabs/input4j/components/DualShock4.java
@@ -2,30 +2,58 @@ package de.gurkenlabs.input4j.components;
 
 import de.gurkenlabs.input4j.InputComponent;
 
+/**
+ * Predefined component identifiers for Sony DualShock 4 controllers.
+ */
 public class DualShock4 {
+  /** Square button. */
   public static final InputComponent.ID SQUARE = new InputComponent.ID(Button.BUTTON_0, "SQUARE");
+  /** Cross button. */
   public static final InputComponent.ID CROSS = new InputComponent.ID(Button.BUTTON_1, "CROSS");
+  /** Circle button. */
   public static final InputComponent.ID CIRCLE = new InputComponent.ID(Button.BUTTON_2, "CIRCLE");
+  /** Triangle button. */
   public static final InputComponent.ID TRIANGLE = new InputComponent.ID(Button.BUTTON_3, "TRIANGLE");
+  /** L1 button (left bumper). */
   public static final InputComponent.ID L1 = new InputComponent.ID(Button.BUTTON_4, "L1");
+  /** R1 button (right bumper). */
   public static final InputComponent.ID R1 = new InputComponent.ID(Button.BUTTON_5, "R1");
+  /** L2 button (left trigger). */
   public static final InputComponent.ID L2 = new InputComponent.ID(Button.BUTTON_6, "L2");
+  /** R2 button (right trigger). */
   public static final InputComponent.ID R2 = new InputComponent.ID(Button.BUTTON_7, "R2");
+  /** Share button. */
   public static final InputComponent.ID SHARE = new InputComponent.ID(Button.BUTTON_8, "SHARE");
+  /** Options button. */
   public static final InputComponent.ID OPTIONS = new InputComponent.ID(Button.BUTTON_9, "OPTIONS");
+  /** Left stick button (L3). */
   public static final InputComponent.ID LEFT_THUMB_PRESS = new InputComponent.ID(Button.BUTTON_10, "LEFT_THUMB_PRESS");
+  /** Right stick button (R3). */
   public static final InputComponent.ID RIGHT_THUMB_PRESS = new InputComponent.ID(Button.BUTTON_11, "RIGHT_THUMB_PRESS");
+  /** PlayStation button. */
   public static final InputComponent.ID PS = new InputComponent.ID(Button.BUTTON_12, "PS");
+  /** Touchpad button. */
   public static final InputComponent.ID TOUCHPAD = new InputComponent.ID(Button.BUTTON_13, "TOUCHPAD");
+  /** D-pad up. */
   public static final InputComponent.ID DPAD_UP = new InputComponent.ID(Button.DPAD_UP);
+  /** D-pad down. */
   public static final InputComponent.ID DPAD_DOWN = new InputComponent.ID(Button.DPAD_DOWN);
+  /** D-pad left. */
   public static final InputComponent.ID DPAD_LEFT = new InputComponent.ID(Button.DPAD_LEFT);
+  /** D-pad right. */
   public static final InputComponent.ID DPAD_RIGHT = new InputComponent.ID(Button.DPAD_RIGHT);
+  /** D-pad as axis (for analog d-pads). */
   public static final InputComponent.ID DPAD = new InputComponent.ID(Axis.AXIS_DPAD);
+  /** Left thumbstick X-axis. */
   public static final InputComponent.ID LEFT_THUMB_X = new InputComponent.ID(Axis.AXIS_X, "LEFT_THUMB_X");
+  /** Left thumbstick Y-axis. */
   public static final InputComponent.ID LEFT_THUMB_Y = new InputComponent.ID(Axis.AXIS_Y, "LEFT_THUMB_Y");
+  /** Right thumbstick X-axis (Z axis on DS4). */
   public static final InputComponent.ID RIGHT_THUMB_X = new InputComponent.ID(Axis.AXIS_Z, "RIGHT_THUMB_X"); // this is actually the Z axis on the DS4
+  /** Right thumbstick Y-axis (RZ axis on DS4). */
   public static final InputComponent.ID RIGHT_THUMB_Y = new InputComponent.ID(Axis.AXIS_RZ, "RIGHT_THUMB_Y"); // this is actually the RZ axis on the DS4
+  /** Left trigger (RX axis on DS4). */
   public static final InputComponent.ID LEFT_TRIGGER = new InputComponent.ID(Axis.AXIS_RX, "LEFT_TRIGGER");
+  /** Right trigger (RY axis on DS4). */
   public static final InputComponent.ID RIGHT_TRIGGER = new InputComponent.ID(Axis.AXIS_RY, "RIGHT_TRIGGER");
 }

--- a/src/main/java/de/gurkenlabs/input4j/examples/ExampleEventBasedInputHandling.java
+++ b/src/main/java/de/gurkenlabs/input4j/examples/ExampleEventBasedInputHandling.java
@@ -6,7 +6,17 @@ import de.gurkenlabs.input4j.components.XInput;
 
 import java.io.IOException;
 
+/**
+ * Example demonstrating event-based input handling.
+ */
 public class ExampleEventBasedInputHandling {
+  /**
+   * Main entry point.
+   *
+   * @param args command line arguments
+   * @throws IOException      if an I/O error occurs
+   * @throws InterruptedException if the thread is interrupted
+   */
   public static void main(String[] args) throws IOException, InterruptedException {
     try (var devices = InputDevices.init()) {
 

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxComponentType.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxComponentType.java
@@ -4,6 +4,9 @@ import de.gurkenlabs.input4j.ComponentType;
 
 import java.util.Arrays;
 
+/**
+ * Linux input event component types mapping to Linux input event codes.
+ */
 public enum LinuxComponentType {
   UNKNOWN(-1),
   KEY_ESC(1),
@@ -384,10 +387,23 @@ public enum LinuxComponentType {
     this.relative = relative;
   }
 
+  /**
+   * Gets the Linux input event code.
+   *
+   * @return the event code
+   */
   public int getCode() {
     return code;
   }
 
+  /**
+   * Gets a LinuxComponentType from a native code.
+   *
+   * @param nativeCode the native Linux input event code
+   * @param axis       true if it's an axis
+   * @param relative   true if it's a relative axis
+   * @return the LinuxComponentType or UNKNOWN
+   */
   public static LinuxComponentType fromCode(int nativeCode, boolean axis, boolean relative) {
     return Arrays.stream(LinuxComponentType.values)
             .filter(type -> type.code == nativeCode && (type.axis == axis && (!relative || type.relative)))
@@ -395,6 +411,14 @@ public enum LinuxComponentType {
             .orElse(UNKNOWN);
   }
 
+  /**
+   * Gets the ComponentType for a native code.
+   *
+   * @param nativeCode the native Linux input event code
+   * @param axis       true if it's an axis
+   * @param relative   true if it's a relative axis
+   * @return the ComponentType
+   */
   public ComponentType getComponentType(int nativeCode, boolean axis, boolean relative) {
     var type = fromCode(nativeCode, axis, relative);
     if (type == UNKNOWN) {
@@ -415,6 +439,11 @@ public enum LinuxComponentType {
     };
   }
 
+  /**
+   * Checks if this component type is an axis (ABS or REL).
+   *
+   * @return true if it's an axis
+   */
   public boolean isAxis() {
     return this.name().startsWith("ABS") || this.name().startsWith("REL");
   }

--- a/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitVirtualComponentHandler.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitVirtualComponentHandler.java
@@ -9,6 +9,9 @@ import de.gurkenlabs.input4j.components.Button;
 import java.util.ArrayList;
 import java.util.Collection;
 
+/**
+ * Handles virtual components for IOKit devices, such as converting D-pad axis values to individual buttons.
+ */
 public class IOKitVirtualComponentHandler {
 
   private IOKitVirtualComponentHandler() {

--- a/src/main/java/de/gurkenlabs/input4j/foreign/windows/dinput/DirectInputPlugin.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/windows/dinput/DirectInputPlugin.java
@@ -20,6 +20,9 @@ import java.util.logging.Level;
 import static de.gurkenlabs.input4j.foreign.NativeHelper.downcallHandle;
 import static java.lang.foreign.ValueLayout.*;
 
+/**
+ * Windows DirectInput plugin for gamepad/controller support.
+ */
 public final class DirectInputPlugin extends AbstractInputDevicePlugin {
   static final int DI8DEVCLASS_GAMECTRL = 4;
 


### PR DESCRIPTION
- Add class-level and constructor Javadoc to Axis, Button, DualShock4
- Add Javadoc to ComponentType enum constants
- Add Javadoc to InputComponent class and ID class methods
- Add Javadoc to IOKitPlugin, IOKitVirtualComponentHandler
- Add Javadoc to DirectInputPlugin
- Add Javadoc to InputDevice.setAccuracy()
- Add Javadoc to LinuxComponentType methods