### PR TITLE
Add input validation and null-safety improvements

### DIFF
--- a/src/main/java/de/gurkenlabs/input4j/InputDevice.java
+++ b/src/main/java/de/gurkenlabs/input4j/InputDevice.java
@@ -233,8 +233,15 @@ public final class InputDevice implements Closeable {
    */
   public void rumble(float... intensity) {
     if (this.rumbleCallback == null) {
-      // rumble not supported if no rumble callback is provided by the library
       return;
+    }
+
+    if (intensity != null) {
+      for (float f : intensity) {
+        if (f < 0 || f > 1) {
+          throw new IllegalArgumentException("Rumble intensity must be between 0 and 1, got: " + f);
+        }
+      }
     }
 
     this.rumbleCallback.accept(this, intensity);

--- a/src/main/java/de/gurkenlabs/input4j/InputDevices.java
+++ b/src/main/java/de/gurkenlabs/input4j/InputDevices.java
@@ -233,9 +233,12 @@ public final class InputDevices {
      * Sets the number of decimal places to round input data to.
      *
      * @param accuracy The number of decimal places. Must be a non-negative integer and should not exceed 7.
-     * @throws IllegalArgumentException if the accuracy is negative.
+     * @throws IllegalArgumentException if the accuracy is negative or exceeds 7.
      */
     public void setAccuracy(int accuracy) {
+      if (accuracy < 0 || accuracy > 7) {
+        throw new IllegalArgumentException("Accuracy must be between 0 and 7, got: " + accuracy);
+      }
       this.accuracy = accuracy;
     }
 

--- a/src/main/java/de/gurkenlabs/input4j/foreign/NativeHelper.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/NativeHelper.java
@@ -9,9 +9,11 @@ import java.lang.invoke.MethodHandle;
 public final class NativeHelper {
 
   public static MethodHandle downcallHandle(String name, FunctionDescriptor fdesc) {
-    return SymbolLookup.loaderLookup().find(name).or(() -> Linker.nativeLinker().defaultLookup().find(name)).
-            map(addr -> Linker.nativeLinker().downcallHandle(addr, fdesc)).
-            orElse(null);
+    return SymbolLookup.loaderLookup().find(name)
+        .or(() -> Linker.nativeLinker().defaultLookup().find(name))
+        .map(addr -> Linker.nativeLinker().downcallHandle(addr, fdesc))
+        .orElseThrow(() -> new UnsatisfiedLinkError(
+            "Native symbol not found: " + name + " with descriptor " + fdesc));
   }
 
   public static MethodHandle downcallHandle(MemorySegment address, FunctionDescriptor fdesc) {


### PR DESCRIPTION
- NativeHelper.downcallHandle() now throws UnsatisfiedLinkError instead of returning null when native symbol is not found
- DefaultInputConfiguration.setAccuracy() now validates that accuracy is between 0 and 7
- InputDevice.rumble() now validates that intensity values are in range [0, 1]

These changes improve fail-fast behavior and provide clearer error messages when invalid parameters are passed.