### PR TITLE
refactor: separate OS detection into PlatformDetector utility

### DIFF
--- a/src/main/java/de/gurkenlabs/input4j/InputDevices.java
+++ b/src/main/java/de/gurkenlabs/input4j/InputDevices.java
@@ -159,9 +159,9 @@ public final class InputDevices {
      *
      * @return The plugin class name.
      */
-    private String getPlugin() {
+    public String getPlugin() {
       return switch (this) {
-        case PLATFORM_DEFAULT -> getCurrentPlatformDefaultPlugin();
+        case PLATFORM_DEFAULT -> InputLibrary.defaultForCurrentOs().getPlugin();
         case WIN_DIRECTINPUT -> "de.gurkenlabs.input4j.foreign.windows.dinput.DirectInputPlugin";
         case WIN_XINPUT -> "de.gurkenlabs.input4j.foreign.windows.xinput.XInputPlugin";
         case LINUX_INPUT -> "de.gurkenlabs.input4j.foreign.linux.LinuxEventDevicePlugin";
@@ -170,31 +170,13 @@ public final class InputDevices {
     }
 
     /**
-     * Detects the current platform and returns the default plugin class name for the platform.
+     * Returns the enum constant that corresponds to the current operating system.
      *
-     * @return The default plugin class name for the current platform.
+     * @return the detected {@code InputLibrary} for the current OS
+     * @throws IllegalStateException if the OS cannot be mapped to a known library
      */
-    private String getCurrentPlatformDefaultPlugin() {
-      String osName = System.getProperty("os.name", "").trim().toLowerCase();
-      String osVersion = System.getProperty("os.version");
-      String osArch = System.getProperty("os.arch");
-
-      log.fine("Detected OS: " + osName + " Version: " + osVersion + " (" + osArch + ")");
-
-      String pluginClassName = null;
-      if (osName.contains("windows")) {
-        pluginClassName = InputLibrary.WIN_XINPUT.getPlugin();
-      } else if (osName.contains("linux")) {
-        pluginClassName = InputLibrary.LINUX_INPUT.getPlugin();
-      } else if (osName.contains("mac os")) {
-        pluginClassName = InputLibrary.MACOS_IOKIT.getPlugin();
-      }
-
-      if (pluginClassName == null) {
-        throw new IllegalStateException("Could not initialize input device provider: Unknown operating system " + osName + " Version: " + osVersion + " (" + osArch + ")");
-      }
-
-      return pluginClassName;
+    public static InputLibrary defaultForCurrentOs() {
+      return de.gurkenlabs.input4j.foreign.util.PlatformDetector.detect();
     }
   }
 

--- a/src/main/java/de/gurkenlabs/input4j/foreign/util/PlatformDetector.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/util/PlatformDetector.java
@@ -1,0 +1,43 @@
+package de.gurkenlabs.input4j.foreign.util;
+
+import java.util.logging.Logger;
+
+/**
+ * Utility class for detecting the current operating system and mapping it to the appropriate
+ * {@link de.gurkenlabs.input4j.InputDevices.InputLibrary} enum constant.
+ *
+ * <p>This class centralises all {@code System.getProperty("os.*")} calls, making the detection
+ * logic easy to mock in unit tests and keeping {@link de.gurkenlabs.input4j.InputDevices.InputLibrary}
+ * free of side‑effects.</p>
+ */
+public final class PlatformDetector {
+  private static final Logger log = Logger.getLogger(PlatformDetector.class.getName());
+
+  private PlatformDetector() {
+    // Utility class – prevent instantiation
+  }
+
+  /**
+   * Detects the current operating system and returns the corresponding {@link de.gurkenlabs.input4j.InputDevices.InputLibrary}
+   * enum constant.
+   *
+   * @return the detected {@code InputLibrary} for the current OS
+   * @throws IllegalStateException if the OS cannot be mapped to a known library
+   */
+  public static de.gurkenlabs.input4j.InputDevices.InputLibrary detect() {
+    String osName = System.getProperty("os.name", "").trim().toLowerCase();
+    String osVersion = System.getProperty("os.version");
+    String osArch = System.getProperty("os.arch");
+    log.fine("Detected OS: " + osName + " Version: " + osVersion + " (" + osArch + ")");
+
+    if (osName.contains("windows")) {
+      return de.gurkenlabs.input4j.InputDevices.InputLibrary.WIN_XINPUT;
+    } else if (osName.contains("linux")) {
+      return de.gurkenlabs.input4j.InputDevices.InputLibrary.LINUX_INPUT;
+    } else if (osName.contains("mac os")) {
+      return de.gurkenlabs.input4j.InputDevices.InputLibrary.MACOS_IOKIT;
+    }
+    throw new IllegalStateException(
+        "Unknown operating system " + osName + " Version: " + osVersion + " (" + osArch + ")");
+  }
+}

--- a/src/test/java/de/gurkenlabs/input4j/foreign/util/PlatformDetectorTests.java
+++ b/src/test/java/de/gurkenlabs/input4j/foreign/util/PlatformDetectorTests.java
@@ -1,0 +1,101 @@
+package de.gurkenlabs.input4j.foreign.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link PlatformDetector}.
+ */
+class PlatformDetectorTests {
+
+  @BeforeEach
+  void setUp() {
+    // Reset any system property changes after each test
+  }
+
+  @AfterEach
+  void tearDown() {
+    // Ensure we restore the original system properties
+    System.clearProperty("os.name");
+    System.clearProperty("os.version");
+    System.clearProperty("os.arch");
+  }
+
+  @Test
+  void testDetect_Windows() {
+    System.setProperty("os.name", "Windows 10");
+    System.setProperty("os.version", "10.0");
+    System.setProperty("os.arch", "x86_64");
+
+    de.gurkenlabs.input4j.InputDevices.InputLibrary lib = de.gurkenlabs.input4j.foreign.util.PlatformDetector.detect();
+    assertEquals(de.gurkenlabs.input4j.InputDevices.InputLibrary.WIN_XINPUT, lib);
+  }
+
+  @Test
+  void testDetect_Linux() {
+    System.setProperty("os.name", "Linux");
+    System.setProperty("os.version", "5.15.0-76-generic");
+    System.setProperty("os.arch", "x86_64");
+
+    de.gurkenlabs.input4j.InputDevices.InputLibrary lib = de.gurkenlabs.input4j.foreign.util.PlatformDetector.detect();
+    assertEquals(de.gurkenlabs.input4j.InputDevices.InputLibrary.LINUX_INPUT, lib);
+  }
+
+  @Test
+  void testDetect_macOS() {
+    System.setProperty("os.name", "Mac OS X");
+    System.setProperty("os.version", "13.0");
+    System.setProperty("os.arch", "x86_64");
+
+    de.gurkenlabs.input4j.InputDevices.InputLibrary lib = de.gurkenlabs.input4j.foreign.util.PlatformDetector.detect();
+    assertEquals(de.gurkenlabs.input4j.InputDevices.InputLibrary.MACOS_IOKIT, lib);
+  }
+
+  @Test
+  void testDetect_UnknownOS() {
+    System.setProperty("os.name", "Solaris");
+    System.setProperty("os.version", "11");
+    System.setProperty("os.arch", "sparc");
+
+    assertThrows(IllegalStateException.class, () -> {
+      de.gurkenlabs.input4j.foreign.util.PlatformDetector.detect();
+    });
+  }
+
+  @Test
+  void testDetect_EmptyOSName() {
+    System.setProperty("os.name", "");
+    System.setProperty("os.version", "1.0");
+    System.setProperty("os.arch", "x86");
+
+    assertThrows(IllegalStateException.class, () -> {
+      de.gurkenlabs.input4j.foreign.util.PlatformDetector.detect();
+    });
+  }
+
+  @Test
+  void testDetect_NullOSName() {
+    System.clearProperty("os.name");
+    System.setProperty("os.version", "1.0");
+    System.setProperty("os.arch", "x86");
+
+    assertThrows(IllegalStateException.class, () -> {
+      de.gurkenlabs.input4j.foreign.util.PlatformDetector.detect();
+    });
+  }
+
+  @Test
+  void testDetect_CaseInsensitive() {
+    System.setProperty("os.name", "windows 11");
+    System.setProperty("os.version", "10.0.22000");
+    System.setProperty("os.arch", "x64");
+
+    de.gurkenlabs.input4j.InputDevices.InputLibrary lib = de.gurkenlabs.input4j.foreign.util.PlatformDetector.detect();
+    assertEquals(de.gurkenlabs.input4j.InputDevices.InputLibrary.WIN_XINPUT, lib);
+  }
+}


### PR DESCRIPTION
- Extract OS detection logic from InputLibrary enum into dedicated PlatformDetector class
- Add public static InputLibrary defaultForCurrentOs() method for cleaner API
- Add comprehensive unit tests covering Windows, Linux, macOS, and error cases
- Improve testability by isolating System.getProperty calls
- Maintain backward compatibility with existing API usage