### PR TITLE
Add JaCoCo XML/HTML report generation for SonarCloud

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,15 @@ test {
   jvmArgs += '--enable-native-access=ALL-UNNAMED'
 }
 
+jacocoTestReport {
+  reports {
+    xml.required = true
+    xml.outputLocation = layout.buildDirectory.file('jacoco/jacoco.xml')
+    html.required = true
+    html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+  }
+}
+
 tasks.register('remoteDebug', JavaExec) {
   mainClass = 'de.gurkenlabs.input4j.examples.ExamplePollAllInputDevicesManually'  // replace with your main class
   classpath = sourceSets.main.runtimeClasspath


### PR DESCRIPTION
Configure jacocoTestReport to generate:
- XML report at build/jacoco/jacoco.xml (for SonarCloud coverage)
- HTML report at build/jacocoHtml/ (for local viewing)