### PR TITLE
fix: use device ID instead of name in XInput rumble

### DIFF
--- a/src/main/java/de/gurkenlabs/input4j/foreign/windows/xinput/XInputPlugin.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/windows/xinput/XInputPlugin.java
@@ -194,9 +194,20 @@ public final class XInputPlugin extends AbstractInputDevicePlugin {
     }
 
     // Set the vibration for each motor (example for two motors)
-    setVibration(Integer.parseInt(inputDevice.getName()),
+    setVibration(resolveDeviceId(inputDevice),
       (short) (motorSpeedLeft * XINPUT_VIBRATION.MAX_VIBRATION),
       (short) (motorSpeedRight * XINPUT_VIBRATION.MAX_VIBRATION));
+  }
+
+  /**
+   * Resolves the numeric device ID from the input device's identifier.
+   *
+   * @param inputDevice The input device.
+   * @return The numeric device ID.
+   * @throws NumberFormatException If the device identifier is not a valid integer.
+   */
+  static int resolveDeviceId(InputDevice inputDevice) {
+    return Integer.parseInt(inputDevice.getID());
   }
 
   /**
@@ -209,8 +220,7 @@ public final class XInputPlugin extends AbstractInputDevicePlugin {
     this.refreshDevices();
     var polledValues = new float[inputDevice.getComponents().size()];
 
-    var deviceId = Integer.parseInt(inputDevice.getID());
-    var state = getState(deviceId);
+    var state = getState(resolveDeviceId(inputDevice));
     if (state == null) {
       return new float[0];
     }

--- a/src/test/java/de/gurkenlabs/input4j/foreign/windows/xinput/XInputPluginTests.java
+++ b/src/test/java/de/gurkenlabs/input4j/foreign/windows/xinput/XInputPluginTests.java
@@ -1,11 +1,13 @@
 package de.gurkenlabs.input4j.foreign.windows.xinput;
 
+import de.gurkenlabs.input4j.InputDevice;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class XInputPluginTests {
   @Test
@@ -61,5 +63,22 @@ public class XInputPluginTests {
 
     // Test case 7: Negative value outside deadzone
     assertEquals(-0.5f, XInputPlugin.normalizeSignedShort((short) -16384, 1000), 0.01);
+  }
+
+  @Test
+  @EnabledOnOs(OS.WINDOWS)
+  void testResolveDeviceId() {
+    var device = new InputDevice("0", "Gamepad (0)", null, _ -> new float[]{}, (_, _) -> {});
+    assertEquals(0, XInputPlugin.resolveDeviceId(device));
+
+    var device2 = new InputDevice("3", "XInput Device (3)", null, _ -> new float[]{}, (_, _) -> {});
+    assertEquals(3, XInputPlugin.resolveDeviceId(device2));
+  }
+
+  @Test
+  @EnabledOnOs(OS.WINDOWS)
+  void testResolveDeviceIdThrowsForNonNumericName() {
+    var device = new InputDevice("Gamepad (0)", "Gamepad (0)", null, _ -> new float[]{}, (_, _) -> {});
+    assertThrows(NumberFormatException.class, () -> XInputPlugin.resolveDeviceId(device));
   }
 }


### PR DESCRIPTION
The rumbleXInputDevice method was calling Integer.parseInt on the device name (e.g. 'Gamepad (0)') instead of the numeric identifier, causing NumberFormatException. Extracted resolveDeviceId helper method and applied it consistently across rumble and poll methods.

Fixes #25