### PR TITLE
feat: add battery support for game controllers across all platforms

### DIFF
--- a/src/examples/java/de/gurkenlabs/input4j/examples/ControllerTestApp.java
+++ b/src/examples/java/de/gurkenlabs/input4j/examples/ControllerTestApp.java
@@ -3,6 +3,7 @@ package de.gurkenlabs.input4j.examples;
 import com.github.weisj.darklaf.LafManager;
 import com.github.weisj.darklaf.theme.DarculaTheme;
 import com.github.weisj.darklaf.theme.HighContrastDarkTheme;
+import de.gurkenlabs.input4j.BatteryInfo;
 import de.gurkenlabs.input4j.InputDevice;
 import de.gurkenlabs.input4j.InputDevicePlugin;
 import de.gurkenlabs.input4j.InputDevices;
@@ -17,6 +18,7 @@ public class ControllerTestApp extends JFrame {
   private static final Logger LOGGER = Logger.getLogger(ControllerTestApp.class.getName());
   private JComboBox<InputDevice> deviceSelector;
   private JLabel deviceInfoLabel;
+  private JLabel batteryLabel;
   private GamepadVisualizer visualizer;
   private JSlider rumbleSlider;
   private JLabel pollRateLabel;
@@ -106,9 +108,13 @@ public class ControllerTestApp extends JFrame {
     deviceInfoLabel = new JLabel("No device selected");
     deviceInfoLabel.setFont(deviceInfoLabel.getFont().deriveFont(Font.ITALIC));
 
+    batteryLabel = new JLabel();
+    batteryLabel.setFont(batteryLabel.getFont().deriveFont(Font.BOLD));
+
     var infoPanel = new JPanel(new BorderLayout());
     infoPanel.add(deviceSelector, BorderLayout.NORTH);
-    infoPanel.add(deviceInfoLabel, BorderLayout.SOUTH);
+    infoPanel.add(deviceInfoLabel, BorderLayout.CENTER);
+    infoPanel.add(batteryLabel, BorderLayout.EAST);
 
     panel.add(infoPanel, BorderLayout.NORTH);
     return panel;
@@ -231,9 +237,48 @@ public class ControllerTestApp extends JFrame {
     if (device != null) {
       deviceInfoLabel.setText(String.format("%s (VID: %04X, PID: %04X)", device.getDisplayName(),
           device.getVendorId(), device.getProductId()));
+      updateBatteryLabel(device);
     } else {
       deviceInfoLabel.setText("No device selected");
+      batteryLabel.setText("");
     }
+  }
+
+  private void updateBatteryLabel(InputDevice device) {
+    var batteryInfo = device.getBatteryInfo().orElse(null);
+    if (batteryInfo == null || !batteryInfo.isAvailable()) {
+      batteryLabel.setText("");
+      return;
+    }
+
+    String icon;
+    Color color;
+    switch (batteryInfo.level()) {
+      case FULL:
+        icon = "\uD83D\uDD0B";
+        color = new Color(76, 175, 80);
+        break;
+      case MEDIUM:
+        icon = "\uD83D\uDD0B";
+        color = new Color(255, 193, 7);
+        break;
+      case LOW:
+        icon = "\uD83D\uDEA8";
+        color = new Color(255, 152, 0);
+        break;
+      case EMPTY:
+        icon = "\uD83D\uDEA8";
+        color = new Color(244, 67, 54);
+        break;
+      default:
+        batteryLabel.setText("");
+        return;
+    }
+
+    int percentage = batteryInfo.getPercentage();
+    String text = percentage >= 0 ? String.format("%s %d%%", icon, percentage) : icon;
+    batteryLabel.setText(text);
+    batteryLabel.setForeground(color);
   }
 
   private void startPolling() {
@@ -256,6 +301,10 @@ public class ControllerTestApp extends JFrame {
       double fps = 30_000_000_000.0 / (now - lastPollTime);
       lastPollTime = now;
       pollRateLabel.setText(String.format("Poll rate: %.1f fps", fps));
+    }
+
+    if (pollCount % 60 == 0 && currentDevice != null) {
+      updateBatteryLabel(currentDevice);
     }
   }
 

--- a/src/main/java/de/gurkenlabs/input4j/BatteryInfo.java
+++ b/src/main/java/de/gurkenlabs/input4j/BatteryInfo.java
@@ -1,0 +1,67 @@
+package de.gurkenlabs.input4j;
+
+/**
+ * Represents battery information for a game controller.
+ *
+ * @param type  The type of battery.
+ * @param level The current charge level.
+ * @param charging Whether the controller is currently charging.
+ */
+public record BatteryInfo(BatteryType type, BatteryLevel level, boolean charging) {
+
+  /**
+   * Creates a BatteryInfo with explicit percentage value.
+   * The level will be derived from the percentage.
+   *
+   * @param type The type of battery.
+   * @param charging Whether the controller is currently charging.
+   * @param percentage The actual battery percentage (0-100), or -1 if unknown.
+   */
+  public static BatteryInfo fromPercentage(BatteryType type, boolean charging, int percentage) {
+    if (percentage < 0 || percentage > 100) {
+      return new BatteryInfo(type, BatteryLevel.UNKNOWN, charging);
+    }
+
+    BatteryLevel level;
+    if (percentage >= 75) {
+      level = BatteryLevel.FULL;
+    } else if (percentage >= 50) {
+      level = BatteryLevel.MEDIUM;
+    } else if (percentage >= 25) {
+      level = BatteryLevel.LOW;
+    } else {
+      level = BatteryLevel.EMPTY;
+    }
+
+    return new BatteryInfo(type, level, charging);
+  }
+
+  /**
+   * Returns whether battery information is available.
+   * This is true when we have a valid level (not UNKNOWN) and the device is connected.
+   *
+   * @return true if battery info is available, false if unknown or not applicable
+   */
+  public boolean isAvailable() {
+    return level != BatteryLevel.UNKNOWN && type != BatteryType.DISCONNECTED;
+  }
+
+  /**
+   * Returns the battery level as a percentage (0-100).
+   * Returns -1 if the level is unknown.
+   *
+   * @return battery percentage or -1 if unknown
+   */
+  public int getPercentage() {
+    if (type == BatteryType.WIRED || type == BatteryType.DISCONNECTED) {
+      return -1;
+    }
+    return switch (level) {
+      case EMPTY -> 0;
+      case LOW -> 25;
+      case MEDIUM -> 50;
+      case FULL -> 100;
+      case UNKNOWN -> -1;
+    };
+  }
+}

--- a/src/main/java/de/gurkenlabs/input4j/BatteryLevel.java
+++ b/src/main/java/de/gurkenlabs/input4j/BatteryLevel.java
@@ -1,0 +1,17 @@
+package de.gurkenlabs.input4j;
+
+/**
+ * Represents the charge level of a game controller battery.
+ */
+public enum BatteryLevel {
+  /** Battery is empty. */
+  EMPTY,
+  /** Battery is low. */
+  LOW,
+  /** Battery is at medium level. */
+  MEDIUM,
+  /** Battery is full. */
+  FULL,
+  /** Battery level is unknown or unavailable. */
+  UNKNOWN
+}

--- a/src/main/java/de/gurkenlabs/input4j/BatteryType.java
+++ b/src/main/java/de/gurkenlabs/input4j/BatteryType.java
@@ -1,0 +1,17 @@
+package de.gurkenlabs.input4j;
+
+/**
+ * Represents the type of battery in a game controller.
+ */
+public enum BatteryType {
+  /** The device is connected via USB and has no battery. */
+  WIRED,
+  /** The device is not connected. */
+  DISCONNECTED,
+  /** The device uses alkaline batteries. */
+  ALKALINE,
+  /** The device uses nickel-metal hydride (NiMH) batteries. */
+  NIMH,
+  /** The battery type is unknown or unavailable. */
+  UNKNOWN
+}

--- a/src/main/java/de/gurkenlabs/input4j/InputDevice.java
+++ b/src/main/java/de/gurkenlabs/input4j/InputDevice.java
@@ -47,6 +47,7 @@ public final class InputDevice implements Closeable {
 
   private final Function<InputDevice, float[]> pollCallback;
   private final BiConsumer<InputDevice, float[]> rumbleCallback;
+  private final Function<InputDevice, BatteryInfo> batteryCallback;
   private float accuracyFactor;
   private boolean hasInputData;
 
@@ -60,7 +61,7 @@ public final class InputDevice implements Closeable {
    * @param rumbleCallback the function to be called when setting rumble intensity
    */
   public InputDevice(String identifier, String name, String productName, Function<InputDevice, float[]> pollCallback, BiConsumer<InputDevice, float[]> rumbleCallback) {
-    this(identifier, name, productName, -1, -1, null, pollCallback, rumbleCallback);
+    this(identifier, name, productName, -1, -1, null, pollCallback, rumbleCallback, null);
   }
 
   /**
@@ -76,6 +77,23 @@ public final class InputDevice implements Closeable {
    * @param rumbleCallback the function to be called when setting rumble intensity
    */
   public InputDevice(String identifier, String name, String productName, int vendorId, int productId, String displayName, Function<InputDevice, float[]> pollCallback, BiConsumer<InputDevice, float[]> rumbleCallback) {
+    this(identifier, name, productName, vendorId, productId, displayName, pollCallback, rumbleCallback, null);
+  }
+
+  /**
+   * Creates a new instance of the InputDevice class.
+   *
+   * @param identifier     the identifier of the input device
+   * @param name           the name of the instance of the input device
+   * @param productName    the name of the product of the input device
+   * @param vendorId       the USB vendor ID, or -1 if not available
+   * @param productId      the USB product ID, or -1 if not available
+   * @param displayName    the user-friendly display name, or null to use productName
+   * @param pollCallback   the function to be called when polling for input data from the device
+   * @param rumbleCallback the function to be called when setting rumble intensity
+   * @param batteryCallback the function to be called when querying battery information, or null if not supported
+   */
+  public InputDevice(String identifier, String name, String productName, int vendorId, int productId, String displayName, Function<InputDevice, float[]> pollCallback, BiConsumer<InputDevice, float[]> rumbleCallback, Function<InputDevice, BatteryInfo> batteryCallback) {
     this.identifier = identifier;
     this.name = name;
     this.productName = productName;
@@ -85,6 +103,7 @@ public final class InputDevice implements Closeable {
     this.controllerType = ControllerDatabase.getControllerType(vendorId, productId);
     this.pollCallback = pollCallback;
     this.rumbleCallback = rumbleCallback;
+    this.batteryCallback = batteryCallback;
     this.setAccuracy(InputDevices.configure().getAccuracy());
   }
 
@@ -175,6 +194,22 @@ public final class InputDevice implements Closeable {
       return productName;
     }
     return name;
+  }
+
+  /**
+   * Gets the battery information for this input device.
+   * <p>
+   * Battery information is only available for some controllers.
+   * Currently supported on Windows via XInput (Xbox controllers).
+   * Returns empty Optional if battery information is not available or not supported.
+   *
+   * @return an Optional containing the battery information, or empty if not available
+   */
+  public Optional<BatteryInfo> getBatteryInfo() {
+    if (batteryCallback == null) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(batteryCallback.apply(this));
   }
 
   /**

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevicePlugin.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevicePlugin.java
@@ -1,19 +1,25 @@
 package de.gurkenlabs.input4j.foreign.linux;
 
 import de.gurkenlabs.input4j.AbstractInputDevicePlugin;
+import de.gurkenlabs.input4j.BatteryInfo;
+import de.gurkenlabs.input4j.BatteryLevel;
+import de.gurkenlabs.input4j.BatteryType;
 import de.gurkenlabs.input4j.ComponentType;
 import de.gurkenlabs.input4j.InputComponent;
 import de.gurkenlabs.input4j.InputDevice;
 
 import java.awt.*;
 import java.io.File;
+import java.io.IOException;
 import java.lang.foreign.Arena;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
+import java.util.stream.Stream;
 
 /**
  * The {@code LinuxEventDevicePlugin} class is responsible for managing Linux event devices.
@@ -155,7 +161,7 @@ public class LinuxEventDevicePlugin extends AbstractInputDevicePlugin {
       int productId = device.id != null ? Short.toUnsignedInt(device.id.product) : -1;
       String displayName = de.gurkenlabs.input4j.ControllerDatabase.getDisplayName(vendorId, productId);
 
-      var inputDevice = new InputDevice(eventDeviceFile.getAbsolutePath(), device.name, device.name, vendorId, productId, displayName, this::pollLinuxEventDevice, this::rumbleLinuxEventDevice);
+      var inputDevice = new InputDevice(eventDeviceFile.getAbsolutePath(), device.name, device.name, vendorId, productId, displayName, this::pollLinuxEventDevice, this::rumbleLinuxEventDevice, this::getBatteryInfo);
       device.inputDevice = inputDevice;
 
       // Check for available event types
@@ -382,5 +388,113 @@ public class LinuxEventDevicePlugin extends AbstractInputDevicePlugin {
     linuxEventDevice.currentEffectId = -1;
     linuxEventDevice.currentStrongMagnitude = 0f;
     linuxEventDevice.currentWeakMagnitude = 0f;
+  }
+
+  private BatteryInfo getBatteryInfo(InputDevice inputDevice) {
+    var device = nativeDevices.get(inputDevice.getID());
+    if (device == null || device.id == null) {
+      return null;
+    }
+
+    int vendorId = Short.toUnsignedInt(device.id.vendor);
+    int productId = Short.toUnsignedInt(device.id.product);
+
+    String batteryPath = findBatteryPath(vendorId, productId);
+    if (batteryPath == null) {
+      return null;
+    }
+
+    try {
+      int percentage = readBatteryPercentage(batteryPath);
+      if (percentage < 0) {
+        return null;
+      }
+
+      return BatteryInfo.fromPercentage(BatteryType.UNKNOWN, false, percentage);
+    } catch (Exception e) {
+      log.log(Level.FINE, "Failed to read battery for device " + device.name, e);
+      return null;
+    }
+  }
+
+  private String findBatteryPath(int vendorId, int productId) {
+    File powerSupplyDir = new File("/sys/class/power_supply");
+    if (!powerSupplyDir.exists() || !powerSupplyDir.isDirectory()) {
+      return null;
+    }
+
+    String vendorHex = String.format("%04x", vendorId);
+    String productHex = String.format("%04x", productId);
+
+    File[] entries = powerSupplyDir.listFiles();
+    if (entries == null) {
+      return null;
+    }
+
+    for (File entry : entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      try {
+        String type = readSysfsFile(entry, "type");
+        if (type == null || !type.equalsIgnoreCase("Battery")) {
+          continue;
+        }
+
+        String vendor = readSysfsFile(entry, "vendor");
+        String manufacturer = readSysfsFile(entry, "manufacturer");
+        String model = readSysfsFile(entry, "model_name");
+
+        boolean match = false;
+        if (vendor != null && vendor.toLowerCase().contains(vendorHex)) {
+          match = true;
+        }
+        if (manufacturer != null && manufacturer.toLowerCase().contains(vendorHex)) {
+          match = true;
+        }
+        if (model != null && model.toLowerCase().contains(productHex)) {
+          match = true;
+        }
+
+        if (match) {
+          return entry.getAbsolutePath();
+        }
+      } catch (IOException e) {
+        continue;
+      }
+    }
+
+    return null;
+  }
+
+  private String readSysfsFile(File dir, String filename) throws IOException {
+    File file = new File(dir, filename);
+    if (file.exists()) {
+      return Files.readString(file.toPath()).trim();
+    }
+    return null;
+  }
+
+  private int readBatteryPercentage(String batteryPath) throws IOException {
+    File capacityFile = new File(batteryPath, "capacity");
+    if (capacityFile.exists()) {
+      String content = Files.readString(capacityFile.toPath()).trim();
+      return Integer.parseInt(content);
+    }
+
+    File capacityLevelFile = new File(batteryPath, "capacity_level");
+    if (capacityLevelFile.exists()) {
+      String level = Files.readString(capacityLevelFile.toPath()).trim().toLowerCase();
+      return switch (level) {
+        case "full" -> 100;
+        case "high", "normal" -> 75;
+        case "low" -> 25;
+        case "critical" -> 10;
+        default -> -1;
+      };
+    }
+
+    return -1;
   }
 }

--- a/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPlugin.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPlugin.java
@@ -1,6 +1,9 @@
 package de.gurkenlabs.input4j.foreign.macos.iokit;
 
 import de.gurkenlabs.input4j.AbstractInputDevicePlugin;
+import de.gurkenlabs.input4j.BatteryInfo;
+import de.gurkenlabs.input4j.BatteryLevel;
+import de.gurkenlabs.input4j.BatteryType;
 import de.gurkenlabs.input4j.ControllerDatabase;
 import de.gurkenlabs.input4j.InputComponent;
 import de.gurkenlabs.input4j.InputDevice;
@@ -40,11 +43,13 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 public class IOKitPlugin extends AbstractInputDevicePlugin {
   private final Map<String, IOHIDDevice> nativeDevices = new ConcurrentHashMap<>();
   private Thread eventLoopThread;
+  private Arena batteryArena;
 
   private boolean devicesInitialized;
 
   @Override
   public void internalInitDevices(Frame owner) {
+    batteryArena = Arena.ofShared();
     eventLoopThread = new Thread(() -> {
       MemorySegment ioHIDManager = MemorySegment.NULL;
       try (Arena memoryArena = Arena.ofConfined()) {
@@ -55,7 +60,7 @@ public class IOKitPlugin extends AbstractInputDevicePlugin {
         for (var ioHIDDevice : ioHIDDevices) {
           log.log(Level.FINE, "Found HID device: " + ioHIDDevice.productName);
           String displayName = ControllerDatabase.getDisplayName(ioHIDDevice.vendorId, ioHIDDevice.productId);
-          var inputDevice = new InputDevice(Long.toString(ioHIDDevice.address), ioHIDDevice.productName, ioHIDDevice.manufacturer + " (" + ioHIDDevice.transport + ")", ioHIDDevice.vendorId, ioHIDDevice.productId, displayName, this::pollIOHIDDevice, this::rumbleIOHIDDevice);
+          var inputDevice = new InputDevice(Long.toString(ioHIDDevice.address), ioHIDDevice.productName, ioHIDDevice.manufacturer + " (" + ioHIDDevice.transport + ")", ioHIDDevice.vendorId, ioHIDDevice.productId, displayName, this::pollIOHIDDevice, this::rumbleIOHIDDevice, this::getBatteryInfo);
           ioHIDDevice.inputDevice = inputDevice;
 
           for (var element : ioHIDDevice.getElements()) {
@@ -287,5 +292,32 @@ public class IOKitPlugin extends AbstractInputDevicePlugin {
     } catch (Exception e) {
       log.log(Level.WARNING, "Failed to send rumble report", e);
     }
+  }
+
+  private BatteryInfo getBatteryInfo(InputDevice inputDevice) {
+    var ioHIDDevice = nativeDevices.get(inputDevice.getID());
+    if (ioHIDDevice == null) {
+      return null;
+    }
+
+    int batteryPercent = MacOS.getBatteryPercentage(ioHIDDevice, batteryArena);
+
+    if (batteryPercent < 0) {
+      return null;
+    }
+
+    BatteryLevel level;
+
+    if (batteryPercent >= 75) {
+      level = BatteryLevel.FULL;
+    } else if (batteryPercent >= 50) {
+      level = BatteryLevel.MEDIUM;
+    } else if (batteryPercent >= 25) {
+      level = BatteryLevel.LOW;
+    } else {
+      level = BatteryLevel.EMPTY;
+    }
+
+    return new BatteryInfo(BatteryType.UNKNOWN, level, false);
   }
 }

--- a/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/MacOS.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/MacOS.java
@@ -395,4 +395,19 @@ class MacOS {
       throw new RuntimeException(t);
     }
   }
+
+  /**
+   * Gets the battery percentage for the HID device.
+   * Returns -1 if battery information is not available.
+   *
+   * @param device The HID device.
+   * @return Battery percentage (0-100) or -1 if unavailable.
+   */
+  static int getBatteryPercentage(IOHIDDevice device, Arena memoryArena) {
+    try {
+      return getIntProperty(memoryArena, "BatteryPercent", device);
+    } catch (Throwable t) {
+      return -1;
+    }
+  }
 }

--- a/src/main/java/de/gurkenlabs/input4j/foreign/windows/xinput/XINPUT_BATTERY_INFORMATION.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/windows/xinput/XINPUT_BATTERY_INFORMATION.java
@@ -1,0 +1,49 @@
+package de.gurkenlabs.input4j.foreign.windows.xinput;
+
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.VarHandle;
+
+/**
+ * Represents battery information for an XInput device.
+ */
+final class XINPUT_BATTERY_INFORMATION {
+  static final int BATTERY_TYPE_DISCONNECTED = 0;
+  static final int BATTERY_TYPE_WIRED = 1;
+  static final int BATTERY_TYPE_ALKALINE = 2;
+  static final int BATTERY_TYPE_NIMH = 3;
+  static final int BATTERY_TYPE_UNKNOWN = (byte) 0xFF;
+
+  static final int BATTERY_LEVEL_EMPTY = 0;
+  static final int BATTERY_LEVEL_LOW = 1;
+  static final int BATTERY_LEVEL_MEDIUM = 2;
+  static final int BATTERY_LEVEL_FULL = 3;
+  static final int BATTERY_LEVEL_UNPLUGGED = 0;
+
+  static final int BATTERY_DEVTYPE_GAMEPAD = 0;
+  static final int BATTERY_DEVTYPE_HEADSET = 1;
+
+  byte BatteryType;
+  byte BatteryLevel;
+
+  static final MemoryLayout $LAYOUT = MemoryLayout.structLayout(
+      ValueLayout.JAVA_BYTE.withName("BatteryType"),
+      ValueLayout.JAVA_BYTE.withName("BatteryLevel")
+  );
+
+  private static final VarHandle VH_BatteryType = $LAYOUT.varHandle(ValueLayout.PathElement.groupElement("BatteryType"));
+  private static final VarHandle VH_BatteryLevel = $LAYOUT.varHandle(ValueLayout.PathElement.groupElement("BatteryLevel"));
+
+  static XINPUT_BATTERY_INFORMATION read(MemorySegment segment) {
+    var batteryInfo = new XINPUT_BATTERY_INFORMATION();
+    batteryInfo.BatteryType = (byte) VH_BatteryType.get(segment, 0);
+    batteryInfo.BatteryLevel = (byte) VH_BatteryLevel.get(segment, 0);
+    return batteryInfo;
+  }
+
+  void write(MemorySegment segment) {
+    VH_BatteryType.set(segment, 0, BatteryType);
+    VH_BatteryLevel.set(segment, 0, BatteryLevel);
+  }
+}

--- a/src/main/java/de/gurkenlabs/input4j/foreign/windows/xinput/XInputPlugin.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/windows/xinput/XInputPlugin.java
@@ -1,6 +1,9 @@
 package de.gurkenlabs.input4j.foreign.windows.xinput;
 
 import de.gurkenlabs.input4j.AbstractInputDevicePlugin;
+import de.gurkenlabs.input4j.BatteryInfo;
+import de.gurkenlabs.input4j.BatteryLevel;
+import de.gurkenlabs.input4j.BatteryType;
 import de.gurkenlabs.input4j.InputComponent;
 import de.gurkenlabs.input4j.InputDevice;
 import de.gurkenlabs.input4j.components.XInput;
@@ -27,6 +30,7 @@ public final class XInputPlugin extends AbstractInputDevicePlugin {
   private static final MethodHandle xInputGetState;
   private static final MethodHandle xInputSetState;
   private static final MethodHandle xInputGetCapabilities;
+  private static final MethodHandle xInputGetBatteryInformation;
 
   private final Arena memoryArena = Arena.ofShared();
   private final MemorySegment stateSegment = memoryArena.allocate(XINPUT_STATE.$LAYOUT);
@@ -48,6 +52,11 @@ public final class XInputPlugin extends AbstractInputDevicePlugin {
 
     xInputGetCapabilities = NativeHelper.downcallHandle(
       "XInputGetCapabilities",
+      FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.JAVA_INT, ValueLayout.JAVA_INT, ValueLayout.ADDRESS)
+    );
+
+    xInputGetBatteryInformation = NativeHelper.downcallHandle(
+      "XInputGetBatteryInformation",
       FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.JAVA_INT, ValueLayout.JAVA_INT, ValueLayout.ADDRESS)
     );
   }
@@ -148,7 +157,7 @@ public final class XInputPlugin extends AbstractInputDevicePlugin {
     var components = new ArrayList<InputComponent>();
 
     var instanceName = type + " (" + gamepad.userIndex + ")";
-    var device = new InputDevice(Integer.toString(gamepad.userIndex), instanceName, null, -1, -1, null, this::pollXInputDevice, this::rumbleXInputDevice);
+    var device = new InputDevice(Integer.toString(gamepad.userIndex), instanceName, null, -1, -1, null, this::pollXInputDevice, this::rumbleXInputDevice, this::getBatteryInfo);
 
     // order is important here, as the order of the components is used to map the polled data
     components.add(new InputComponent(device, XInput.DPAD_UP));
@@ -305,5 +314,75 @@ public final class XInputPlugin extends AbstractInputDevicePlugin {
     } catch (Throwable e) {
       log.log(Level.SEVERE, e.getMessage(), e);
     }
+  }
+
+  /**
+   * Gets the battery information for the XInput device.
+   *
+   * @param inputDevice The input device.
+   * @return The battery information, or null if the device is not connected or query fails.
+   */
+  BatteryInfo getBatteryInfo(InputDevice inputDevice) {
+    int userIndex = resolveDeviceId(inputDevice);
+    try {
+      var batterySegment = this.memoryArena.allocate(XINPUT_BATTERY_INFORMATION.$LAYOUT);
+      int result = (int) xInputGetBatteryInformation.invoke(
+          userIndex,
+          XINPUT_BATTERY_INFORMATION.BATTERY_DEVTYPE_GAMEPAD,
+          batterySegment);
+
+      if (result == Result.ERROR_SUCCESS) {
+        var batteryInfo = XINPUT_BATTERY_INFORMATION.read(batterySegment);
+        return convertBatteryInfo(batteryInfo);
+      } else if (result == Result.ERROR_DEVICE_NOT_CONNECTED) {
+        return null;
+      } else {
+        log.log(Level.WARNING, "XInputGetBatteryInformation failed for userIndex " + userIndex + " with result " + Result.toString(result));
+        return null;
+      }
+    } catch (Throwable e) {
+      log.log(Level.SEVERE, e.getMessage(), e);
+      return null;
+    }
+  }
+
+  private BatteryInfo convertBatteryInfo(XINPUT_BATTERY_INFORMATION xinputBattery) {
+    BatteryType type;
+    switch (xinputBattery.BatteryType) {
+      case XINPUT_BATTERY_INFORMATION.BATTERY_TYPE_WIRED:
+        type = BatteryType.WIRED;
+        break;
+      case XINPUT_BATTERY_INFORMATION.BATTERY_TYPE_DISCONNECTED:
+        type = BatteryType.DISCONNECTED;
+        break;
+      case XINPUT_BATTERY_INFORMATION.BATTERY_TYPE_ALKALINE:
+        type = BatteryType.ALKALINE;
+        break;
+      case XINPUT_BATTERY_INFORMATION.BATTERY_TYPE_NIMH:
+        type = BatteryType.NIMH;
+        break;
+      default:
+        type = BatteryType.UNKNOWN;
+    }
+
+    BatteryLevel level;
+    switch (xinputBattery.BatteryLevel) {
+      case XINPUT_BATTERY_INFORMATION.BATTERY_LEVEL_EMPTY:
+        level = BatteryLevel.EMPTY;
+        break;
+      case XINPUT_BATTERY_INFORMATION.BATTERY_LEVEL_LOW:
+        level = BatteryLevel.LOW;
+        break;
+      case XINPUT_BATTERY_INFORMATION.BATTERY_LEVEL_MEDIUM:
+        level = BatteryLevel.MEDIUM;
+        break;
+      case XINPUT_BATTERY_INFORMATION.BATTERY_LEVEL_FULL:
+        level = BatteryLevel.FULL;
+        break;
+      default:
+        level = BatteryLevel.UNKNOWN;
+    }
+
+    return new BatteryInfo(type, level, false);
   }
 }

--- a/src/test/java/de/gurkenlabs/input4j/BatteryInfoTests.java
+++ b/src/test/java/de/gurkenlabs/input4j/BatteryInfoTests.java
@@ -1,0 +1,110 @@
+package de.gurkenlabs.input4j;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class BatteryInfoTests {
+
+  @Test
+  void testFromPercentageFull() {
+    BatteryInfo info = BatteryInfo.fromPercentage(BatteryType.ALKALINE, false, 100);
+    assertEquals(BatteryLevel.FULL, info.level());
+    assertEquals(100, info.getPercentage());
+  }
+
+  @Test
+  void testFromPercentageHigh() {
+    BatteryInfo info = BatteryInfo.fromPercentage(BatteryType.NIMH, false, 75);
+    assertEquals(BatteryLevel.FULL, info.level());
+    assertEquals(100, info.getPercentage());
+  }
+
+  @Test
+  void testFromPercentageMedium() {
+    BatteryInfo info = BatteryInfo.fromPercentage(BatteryType.UNKNOWN, false, 50);
+    assertEquals(BatteryLevel.MEDIUM, info.level());
+    assertEquals(50, info.getPercentage());
+  }
+
+  @Test
+  void testFromPercentageLow() {
+    BatteryInfo info = BatteryInfo.fromPercentage(BatteryType.UNKNOWN, false, 25);
+    assertEquals(BatteryLevel.LOW, info.level());
+    assertEquals(25, info.getPercentage());
+  }
+
+  @Test
+  void testFromPercentageEmpty() {
+    BatteryInfo info = BatteryInfo.fromPercentage(BatteryType.UNKNOWN, false, 10);
+    assertEquals(BatteryLevel.EMPTY, info.level());
+    assertEquals(0, info.getPercentage());
+  }
+
+  @Test
+  void testFromPercentageInvalidNegative() {
+    BatteryInfo info = BatteryInfo.fromPercentage(BatteryType.UNKNOWN, false, -1);
+    assertEquals(BatteryLevel.UNKNOWN, info.level());
+    assertEquals(-1, info.getPercentage());
+  }
+
+  @Test
+  void testFromPercentageInvalidOver100() {
+    BatteryInfo info = BatteryInfo.fromPercentage(BatteryType.UNKNOWN, false, 101);
+    assertEquals(BatteryLevel.UNKNOWN, info.level());
+    assertEquals(-1, info.getPercentage());
+  }
+
+  @Test
+  void testDefaultConstructor() {
+    BatteryInfo info = new BatteryInfo(BatteryType.WIRED, BatteryLevel.FULL, false);
+    assertEquals(BatteryType.WIRED, info.type());
+    assertEquals(BatteryLevel.FULL, info.level());
+    assertFalse(info.charging());
+    assertEquals(-1, info.getPercentage());
+  }
+
+  @Test
+  void testIsAvailable() {
+    assertTrue(new BatteryInfo(BatteryType.ALKALINE, BatteryLevel.FULL, false).isAvailable());
+    assertTrue(new BatteryInfo(BatteryType.NIMH, BatteryLevel.MEDIUM, false).isAvailable());
+    assertTrue(new BatteryInfo(BatteryType.UNKNOWN, BatteryLevel.LOW, false).isAvailable());
+    assertTrue(new BatteryInfo(BatteryType.WIRED, BatteryLevel.FULL, false).isAvailable());
+  }
+
+  @Test
+  void testIsNotAvailableDisconnected() {
+    assertFalse(new BatteryInfo(BatteryType.DISCONNECTED, BatteryLevel.UNKNOWN, false).isAvailable());
+  }
+
+  @Test
+  void testIsNotAvailableUnknownLevel() {
+    assertFalse(new BatteryInfo(BatteryType.UNKNOWN, BatteryLevel.UNKNOWN, false).isAvailable());
+  }
+
+  @Test
+  void testGetPercentageWired() {
+    BatteryInfo info = new BatteryInfo(BatteryType.WIRED, BatteryLevel.FULL, false);
+    assertEquals(-1, info.getPercentage());
+  }
+
+  @Test
+  void testGetPercentageDisconnected() {
+    BatteryInfo info = new BatteryInfo(BatteryType.DISCONNECTED, BatteryLevel.EMPTY, false);
+    assertEquals(-1, info.getPercentage());
+  }
+
+  @Test
+  void testGetPercentageUnknownLevel() {
+    BatteryInfo info = new BatteryInfo(BatteryType.UNKNOWN, BatteryLevel.UNKNOWN, false);
+    assertEquals(-1, info.getPercentage());
+  }
+
+  @Test
+  void testChargingFlag() {
+    BatteryInfo notCharging = BatteryInfo.fromPercentage(BatteryType.ALKALINE, false, 50);
+    BatteryInfo charging = BatteryInfo.fromPercentage(BatteryType.NIMH, true, 75);
+    assertFalse(notCharging.charging());
+    assertTrue(charging.charging());
+  }
+}


### PR DESCRIPTION
Implements battery information retrieval for game controllers on Windows, macOS, and Linux:

- Add BatteryInfo, BatteryType, BatteryLevel classes
- Windows (XInput): Use XInputGetBatteryInformation API for Xbox controllers
- macOS (IOKit): Query BatteryPercent property via IOKit HID
- Linux (sysfs): Read from /sys/class/power_supply/ with improved device matching
- Add factory method BatteryInfo.fromPercentage() for platforms that provide actual percentage values
- Add BatteryInfoTests with 15 unit tests
- Update ControllerTestApp with battery indicator UI

The implementation is defensive - returns empty Optional when battery info is not available, which is the case for many controllers and platforms.