### PR TITLE
fix: initialize time field in input_event to prevent NPE on Linux rumble

### DIFF
--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/input_event.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/input_event.java
@@ -9,10 +9,19 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_SHORT;
 
 /*
- * The event structure itself
+ * The event structure itself.
+ *
+ * <p>
+ * Corresponds to {@code struct input_event} from {@code linux/input.h}.
+ * The {@code time} field contains a timestamp for the event. When writing events
+ * to the device (e.g., for force feedback), the kernel ignores zero timestamps
+ * or replaces them with the current time, so initializing to zero is safe
+ * and the preferred approach for user-space generated events.
+ *
+ * @see <a href="https://www.kernel.org/doc/html/latest/input/uinput.html">uinput module</a>
  */
 class input_event {
-  public timeval time;
+  public timeval time = new timeval();
   public short type;
   public short code;
   public int value;

--- a/src/test/java/de/gurkenlabs/input4j/foreign/linux/LinuxDataStructTests.java
+++ b/src/test/java/de/gurkenlabs/input4j/foreign/linux/LinuxDataStructTests.java
@@ -124,6 +124,31 @@ public class LinuxDataStructTests {
   }
 
   @Test
+  public void testInputEventTimeInitialized() {
+    var inputEvent = new input_event();
+    assertNotNull(inputEvent.time, "time field should be initialized and not null");
+    assertEquals(0, inputEvent.time.tv_sec, "time.tv_sec should default to 0");
+    assertEquals(0, inputEvent.time.tv_usec, "time.tv_usec should default to 0");
+  }
+
+  @Test
+  public void testInputEventWriteWithoutExplicitTimeSet() {
+    try (var memorySession = Arena.ofConfined()) {
+      var inputEvent = new input_event();
+      inputEvent.type = 1;
+      inputEvent.code = 50;
+      inputEvent.value = 100;
+
+      var segment = memorySession.allocate(input_event.$LAYOUT);
+      assertDoesNotThrow(() -> inputEvent.write(segment));
+
+      var inputEventFromMemory = input_event.read(segment);
+      assertEquals(0, inputEventFromMemory.time.tv_sec);
+      assertEquals(0, inputEventFromMemory.time.tv_usec);
+    }
+  }
+
+  @Test
   @EnabledOnOs(OS.LINUX)
   void testTimevalLayoutSize() {
     String osArch = System.getProperty("os.arch", "").toLowerCase();


### PR DESCRIPTION
The input_event.time field was not initialized when creating new input_event objects, causing a NullPointerException when writing rumble events to the device in LinuxEventDevicePlugin.setGain() and rumble operations.

This change initializes time to a zero-initialized timeval, which is safe per the Linux kernel documentation - timestamps are ignored or replaced with the current time by the kernel when writing to /dev/input/event devices.

Fixes #45.