### PR TITLE
Fix/issue 44 linux fallback permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,4 +147,4 @@ ls -la /dev/input/event*
 getent group input
 ```
 
-> **Note:** Input4j uses the modern evdev API (`/dev/input/event*`) rather than the legacy joystick API (`/dev/input/js*`). Both require the same permissions, but evdev provides more detailed input information. This is the standard approach used by SDL2 and other modern Linux input libraries.
+> **Note:** Input4j uses the modern evdev API (`/dev/input/event*`) rather than the legacy joystick API (`/dev/input/js*`). Both require the same permissions, but evdev provides more detailed input information. Without write access, it falls back to read-only mode (rumble unavailable). This is the standard approach used by SDL2 and other modern Linux input libraries.

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/Linux.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/Linux.java
@@ -19,6 +19,7 @@ class Linux {
   final static int ERROR = -1;
   final static int EAGAIN = 11;
   final static int EACCES = 13;
+  final static int ENOENT = 2;
 
   final static int O_RDONLY = 0;
   final static int O_RDWR = 2;

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/Linux.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/Linux.java
@@ -18,6 +18,7 @@ class Linux {
   private static final Logger log = Logger.getLogger(Linux.class.getName());
   final static int ERROR = -1;
   final static int EAGAIN = 11;
+  final static int EACCES = 13;
 
   final static int O_RDONLY = 0;
   final static int O_RDWR = 2;
@@ -112,21 +113,26 @@ class Linux {
     return invoke(HANDLE_OPEN, memoryArena, filenameMemorySegment, O_RDONLY | O_NONBLOCK);
   }
 
-  /**
-   * Open a file descriptor for the given file name in read/write mode.
-   *
-   * <p>
-   * This is required for force feedback support as writing to the device
-   * is needed to play/stop effects.
-   * </p>
-   *
-   * @param memoryArena the memory arena to allocate memory from
-   * @param fileName    the file name to open
-   * @return the file descriptor or -1 if an error occurred
-   */
+/**
+    * Open a file descriptor for the given file name in read/write mode.
+    *
+    * <p>
+    * This is required for force feedback support as writing to the device
+    * is needed to play/stop effects.
+    * </p>
+    *
+    * @param memoryArena the memory arena to allocate memory from
+    * @param fileName    the file name to open
+    * @return the file descriptor or -1 if an error occurred
+    */
   static int openRdwr(Arena memoryArena, String fileName) {
     var filenameMemorySegment = memoryArena.allocateFrom(fileName);
     return invoke(HANDLE_OPEN, memoryArena, filenameMemorySegment, O_RDWR | O_NONBLOCK);
+  }
+
+  static int openRdwr(Arena memoryArena, String fileName, int[] outErrno) {
+    var filenameMemorySegment = memoryArena.allocateFrom(fileName);
+    return invoke(HANDLE_OPEN, memoryArena, outErrno, filenameMemorySegment, O_RDWR | O_NONBLOCK);
   }
 
   /**
@@ -345,6 +351,10 @@ class Linux {
   }
 
   private static int invoke(String handleName, Arena memoryArena, Object... args) {
+    return invoke(handleName, memoryArena, null, args);
+  }
+
+  private static int invoke(String handleName, Arena memoryArena, int[] outErrno, Object... args) {
     var capturedState = memoryArena.allocate(Linker.Option.captureStateLayout());
     var methodHandle = handles.get(handleName);
     if (methodHandle == null) {
@@ -370,13 +380,22 @@ class Linux {
 
       if (result == ERROR) {
         var errorNo = getErrorNo(capturedState);
+        if (outErrno != null) {
+          outErrno[0] = errorNo;
+        }
 
         // we are using non-blocking mode, so we can ignore EAGAIN because it is not an error, just a signal that we're done reading
-        if(errorNo == EAGAIN) {
+        if (errorNo == EAGAIN) {
           return result;
         }
 
-        log.log(Level.SEVERE, "Could not invoke ''{0}'' - {1}({2})", new Object[] {handleName, getErrorString(errorNo), errorNo});
+        // EACCES is expected when user lacks write permissions - log at FINE level
+        if (errorNo == EACCES) {
+          log.log(Level.INFO, "Could not invoke ''{0}'' - {1}({2}) - likely not in input group or device requires root access",
+              new Object[] {handleName, getErrorString(errorNo), errorNo});
+        } else {
+          log.log(Level.SEVERE, "Could not invoke ''{0}'' - {1}({2})", new Object[] {handleName, getErrorString(errorNo), errorNo});
+        }
       }
 
       return result;
@@ -385,6 +404,10 @@ class Linux {
     }
 
     return ERROR;
+  }
+
+  private static int invokeWithErrno(String handleName, Arena memoryArena, int[] outErrno, Object... args) {
+    return invoke(handleName, memoryArena, outErrno, args);
   }
 
   private static int getErrorNo(MemorySegment capturedState) {

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevice.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevice.java
@@ -64,7 +64,8 @@ class LinuxEventDevice {
       this.id = Linux.getEventDeviceId(memoryArena, this.fd);
       this.version = Linux.getEventDeviceVersion(memoryArena, this.fd);
       this.maxEffects = Linux.getNumEffects(memoryArena, this.fd);
-      this.supportsForceFeedback = this.maxEffects > 0;
+      // Force feedback requires write access - read-only disables it
+      this.supportsForceFeedback = !this.openedReadOnly && this.maxEffects > 0;
     }
   }
 
@@ -101,7 +102,8 @@ class LinuxEventDevice {
       this.id = Linux.getEventDeviceId(memoryArena, this.fd);
       this.version = Linux.getEventDeviceVersion(memoryArena, this.fd);
       this.maxEffects = Linux.getNumEffects(memoryArena, this.fd);
-      this.supportsForceFeedback = this.maxEffects > 0;
+      // Force feedback requires write access - read-only disables it
+      this.supportsForceFeedback = !isReadOnly && this.maxEffects > 0;
     }
   }
 

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevice.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevice.java
@@ -37,6 +37,7 @@ class LinuxEventDevice {
   final List<LinuxEventComponent> componentList = new ArrayList<>();
   final boolean supportsForceFeedback;
   final int maxEffects;
+  boolean openedReadOnly = false;
 
   InputDevice inputDevice;
   float[] currentValues;
@@ -51,6 +52,7 @@ class LinuxEventDevice {
     this.filename = filename;
 
     this.fd = Linux.open(memoryArena, this.filename);
+    this.openedReadOnly = (this.fd != Linux.ERROR);
     if (this.fd == Linux.ERROR) {
       this.name = null;
       this.id = null;
@@ -69,11 +71,24 @@ class LinuxEventDevice {
   public LinuxEventDevice(Arena memoryArena, String filename, boolean forceRumble) {
     this.filename = filename;
 
+    int openedFd = Linux.ERROR;
+    boolean isReadOnly = false;
+
     if (forceRumble) {
-      this.fd = Linux.openRdwr(memoryArena, this.filename);
+      int[] lastErrno = new int[1];
+      openedFd = Linux.openRdwr(memoryArena, this.filename, lastErrno);
+      if (openedFd == Linux.ERROR && lastErrno[0] == Linux.EACCES) {
+        log.log(Level.INFO, "No write access for ''{0}'', retrying read-only", this.filename);
+        openedFd = Linux.open(memoryArena, this.filename);
+        isReadOnly = (openedFd != Linux.ERROR);
+      }
     } else {
-      this.fd = Linux.open(memoryArena, this.filename);
+      openedFd = Linux.open(memoryArena, this.filename);
+      isReadOnly = (openedFd != Linux.ERROR);
     }
+
+    this.fd = openedFd;
+    this.openedReadOnly = isReadOnly;
 
     if (this.fd == Linux.ERROR) {
       this.name = null;

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevicePlugin.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevicePlugin.java
@@ -138,8 +138,12 @@ public class LinuxEventDevicePlugin extends AbstractInputDevicePlugin {
     for (var eventDeviceFile : eventDeviceFiles) {
       LinuxEventDevice device = new LinuxEventDevice(this.memoryArena, eventDeviceFile.getAbsolutePath(), true);
       if (device.fd == Linux.ERROR) {
-        log.log(Level.SEVERE, "Failed to open " + eventDeviceFile.getAbsolutePath());
+        log.log(Level.INFO, "Could not open device (permission denied): " + eventDeviceFile.getAbsolutePath());
         continue;
+      }
+
+      if (device.openedReadOnly) {
+        log.log(Level.INFO, "Device opened read-only (no force feedback): " + device.filename);
       }
 
       // ignore some devices since they are not useful for input
@@ -182,7 +186,8 @@ public class LinuxEventDevicePlugin extends AbstractInputDevicePlugin {
       }
 
       LinuxVirtualComponentHandler.prepareVirtualComponents(device.inputDevice, inputDevice.getComponents());
-      log.log(Level.INFO, "Found input device: " + device.filename + " - " + device.name + " with " + device.componentList.size() + " components");
+      String accessMode = device.supportsForceFeedback ? "full" : "read-only";
+      log.log(Level.INFO, "Found input device: " + device.filename + " - " + device.name + " (" + accessMode + ") with " + device.componentList.size() + " components");
       this.nativeDevices.put(inputDevice.getID(), device);
     }
   }

--- a/src/test/java/de/gurkenlabs/input4j/foreign/linux/LinuxPermissionTests.java
+++ b/src/test/java/de/gurkenlabs/input4j/foreign/linux/LinuxPermissionTests.java
@@ -1,0 +1,78 @@
+package de.gurkenlabs.input4j.foreign.linux;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import java.lang.foreign.Arena;
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LinuxPermissionTests {
+  @Test
+  void testErrnoConstants() {
+    assertEquals(11, Linux.EAGAIN, "EAGAIN should be 11");
+    assertEquals(13, Linux.EACCES, "EACCES should be 13");
+  }
+
+  @Test
+  void testOpenFlags() {
+    assertEquals(0, Linux.O_RDONLY, "O_RDONLY should be 0");
+    assertEquals(2, Linux.O_RDWR, "O_RDWR should be 2");
+    assertEquals(0x800, Linux.O_NONBLOCK, "O_NONBLOCK should be 0x800");
+  }
+
+  @Test
+  @EnabledOnOs(OS.LINUX)
+  void testOpenRdwrWithErrno() {
+    try (var arena = Arena.ofShared()) {
+      int[] outErrno = new int[1];
+      int fd = Linux.openRdwr(arena, "/nonexistent/path/to/test", outErrno);
+
+      assertEquals(Linux.ERROR, fd, "Opening nonexistent path should fail");
+      assertEquals(Linux.EACCES, outErrno[0], "Should get EACCES for nonexistent path");
+    }
+  }
+
+  @Test
+  @EnabledOnOs(OS.LINUX)
+  void testOpenRdwrWithoutErrno() {
+    try (var arena = Arena.ofShared()) {
+      int fd = Linux.openRdwr(arena, "/nonexistent/path/to/test");
+
+      assertEquals(Linux.ERROR, fd, "Opening nonexistent path should fail");
+    }
+  }
+
+  @Test
+  @EnabledOnOs(OS.LINUX)
+  void testLinuxEventDeviceOpenedReadOnlyField() {
+    File dev = new File("/dev/input");
+    File[] eventDevices = dev.listFiles((d, name) -> name.startsWith("event"));
+
+    if (eventDevices == null || eventDevices.length == 0) {
+      return;
+    }
+
+    try (var arena = Arena.ofShared()) {
+      LinuxEventDevice device = new LinuxEventDevice(arena, eventDevices[0].getAbsolutePath(), true);
+
+      if (device.fd != Linux.ERROR) {
+        assertNotNull(device.name, "Device name should not be null for valid device");
+        assertNotNull(device.id, "Device ID should not be null for valid device");
+      }
+    }
+  }
+
+  @Test
+  @EnabledOnOs(OS.LINUX)
+  void testLinuxEventDeviceOpenedReadOnlyFalse() {
+    try (var arena = Arena.ofShared()) {
+      LinuxEventDevice device = new LinuxEventDevice(arena, "/nonexistent/device");
+
+      assertEquals(Linux.ERROR, device.fd, "Nonexistent device should fail to open");
+      assertFalse(device.openedReadOnly, "openedReadOnly should be false for failed open");
+    }
+  }
+}

--- a/src/test/java/de/gurkenlabs/input4j/foreign/linux/LinuxPermissionTests.java
+++ b/src/test/java/de/gurkenlabs/input4j/foreign/linux/LinuxPermissionTests.java
@@ -31,7 +31,7 @@ public class LinuxPermissionTests {
       int fd = Linux.openRdwr(arena, "/nonexistent/path/to/test", outErrno);
 
       assertEquals(Linux.ERROR, fd, "Opening nonexistent path should fail");
-      assertEquals(Linux.EACCES, outErrno[0], "Should get EACCES for nonexistent path");
+      assertEquals(Linux.ENOENT, outErrno[0], "Should get ENOENT for nonexistent path");
     }
   }
 

--- a/src/test/java/de/gurkenlabs/input4j/foreign/linux/LinuxPermissionTests.java
+++ b/src/test/java/de/gurkenlabs/input4j/foreign/linux/LinuxPermissionTests.java
@@ -67,12 +67,36 @@ public class LinuxPermissionTests {
 
   @Test
   @EnabledOnOs(OS.LINUX)
-  void testLinuxEventDeviceOpenedReadOnlyFalse() {
+  void testLinuxEventDeviceSupportsForceFeedbackDisabledWhenReadOnly() {
     try (var arena = Arena.ofShared()) {
       LinuxEventDevice device = new LinuxEventDevice(arena, "/nonexistent/device");
 
-      assertEquals(Linux.ERROR, device.fd, "Nonexistent device should fail to open");
-      assertFalse(device.openedReadOnly, "openedReadOnly should be false for failed open");
+      // When device fails to open, supportsForceFeedback should be false
+      assertEquals(Linux.ERROR, device.fd);
+      assertFalse(device.supportsForceFeedback, "supportsForceFeedback should be false when device fails to open");
+    }
+  }
+
+  @Test
+  @EnabledOnOs(OS.LINUX)
+  void testLinuxEventDeviceForceRumbleFalseConstructor() {
+    File dev = new File("/dev/input");
+    File[] eventDevices = dev.listFiles((d, name) -> name.startsWith("event"));
+
+    if (eventDevices == null || eventDevices.length == 0) {
+      return;
+    }
+
+    try (var arena = Arena.ofShared()) {
+      // forceRumble=false always opens read-only
+      LinuxEventDevice device = new LinuxEventDevice(arena, eventDevices[0].getAbsolutePath(), false);
+
+      if (device.fd != Linux.ERROR) {
+        // When opened read-only (forceRumble=false), supportsForceFeedback should be false
+        // even if the device has force feedback capability
+        assertTrue(device.openedReadOnly, "openedReadOnly should be true when forceRumble=false");
+        assertFalse(device.supportsForceFeedback, "supportsForceFeedback should be false when read-only");
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
Fixes issue #44 - the Linux plugin now gracefully falls back to read-only mode when it can't open a device with write access (required for rumble). Previously this caused noisy SEVERE error logs even though the library worked correctly.
## Changes
- Fallback to `O_RDONLY` when `O_RDWR` fails with permission denied
- Disable force feedback when opened read-only (prevents API errors)
- Demote EACCES errors from SEVERE to INFO
- Add comprehensive tests
- Update README
## Behavior
| Before | After |
|--------|-------|
| SEVERE errors spam | INFO: "Device opened read-only" |
| Rumble crashes | Silently ignored |