### PR TITLE
Fix/issue 51 linux mapping

### DIFF
--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventCode.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventCode.java
@@ -1,0 +1,43 @@
+package de.gurkenlabs.input4j.foreign.linux;
+
+public final class LinuxEventCode {
+  public static final int BTN_0 = 0x100;
+  public static final int BTN_1 = 0x101;
+  public static final int BTN_2 = 0x102;
+  public static final int BTN_3 = 0x103;
+  public static final int BTN_4 = 0x104;
+  public static final int BTN_5 = 0x105;
+  public static final int BTN_6 = 0x106;
+  public static final int BTN_7 = 0x107;
+  public static final int BTN_8 = 0x108;
+  public static final int BTN_9 = 0x109;
+
+  public static final int BTN_SOUTH = 0x13a;
+  public static final int BTN_EAST = 0x13b;
+  public static final int BTN_WEST = 0x13c;
+  public static final int BTN_NORTH = 0x13d;
+
+  public static final int BTN_TL = 0x13e;
+  public static final int BTN_TR = 0x13f;
+  public static final int BTN_SELECT = 0x136;
+  public static final int BTN_START = 0x137;
+  public static final int BTN_MODE = 0x13f;
+  public static final int BTN_THUMBL = 0x13d;
+  public static final int BTN_THUMBR = 0x13e;
+
+  public static final int BTN_TRIGGER_HAPPY1 = 0x2c0;
+  public static final int BTN_TRIGGER_HAPPY2 = 0x2c1;
+  public static final int BTN_TRIGGER_HAPPY3 = 0x2c2;
+  public static final int BTN_TRIGGER_HAPPY4 = 0x2c3;
+
+  public static final int ABS_X = 0x00;
+  public static final int ABS_Y = 0x01;
+  public static final int ABS_Z = 0x02;
+  public static final int ABS_RX = 0x03;
+  public static final int ABS_RY = 0x04;
+  public static final int ABS_RZ = 0x05;
+  public static final int ABS_HAT0X = 0x10;
+  public static final int ABS_HAT0Y = 0x11;
+
+  private LinuxEventCode() {}
+}

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventCode.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventCode.java
@@ -1,5 +1,11 @@
 package de.gurkenlabs.input4j.foreign.linux;
 
+/**
+ * Linux input event codes from {@code input-event-codes.h}.
+ * Values match the Linux kernel UAPI definitions.
+ *
+ * @see <a href="https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/input-event-codes.h">input-event-codes.h</a>
+ */
 public final class LinuxEventCode {
   public static final int BTN_0 = 0x100;
   public static final int BTN_1 = 0x101;
@@ -12,19 +18,20 @@ public final class LinuxEventCode {
   public static final int BTN_8 = 0x108;
   public static final int BTN_9 = 0x109;
 
-  public static final int BTN_SOUTH = 0x13a;
-  public static final int BTN_EAST = 0x13b;
-  public static final int BTN_WEST = 0x13c;
-  public static final int BTN_NORTH = 0x13d;
+  public static final int BTN_SOUTH = 0x130;
+  public static final int BTN_EAST = 0x131;
+  public static final int BTN_WEST = 0x134;
+  public static final int BTN_NORTH = 0x133;
 
-  public static final int BTN_TL = 0x13e;
-  public static final int BTN_TR = 0x13f;
-  public static final int BTN_SELECT = 0x136;
-  public static final int BTN_START = 0x137;
-  public static final int BTN_MODE = 0x13f;
+  public static final int BTN_TL = 0x136;
+  public static final int BTN_TR = 0x137;
+  public static final int BTN_SELECT = 0x13a;
+  public static final int BTN_START = 0x13b;
+  public static final int BTN_MODE = 0x13c;
   public static final int BTN_THUMBL = 0x13d;
   public static final int BTN_THUMBR = 0x13e;
 
+  public static final int BTN_TRIGGER_HAPPY = 0x2c0;
   public static final int BTN_TRIGGER_HAPPY1 = 0x2c0;
   public static final int BTN_TRIGGER_HAPPY2 = 0x2c1;
   public static final int BTN_TRIGGER_HAPPY3 = 0x2c2;

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventComponent.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventComponent.java
@@ -6,7 +6,13 @@ import de.gurkenlabs.input4j.InputComponent;
 import de.gurkenlabs.input4j.components.Axis;
 import de.gurkenlabs.input4j.components.Button;
 
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 final class LinuxEventComponent {
+  private static final Logger log = Logger.getLogger(LinuxEventComponent.class.getName());
+
   static final String ID_DPAD_LEFT_RIGHT = "DPAD_LEFT_RIGHT";
   static final String ID_DPAD_UP_DOWN = "DPAD_UP_DOWN";
 
@@ -21,13 +27,25 @@ final class LinuxEventComponent {
   final int nativeType;
   final int nativeCode;
 
+  final int vendorId;
+  final int productId;
+  final String deviceName;
+
   InputComponent inputComponent;
 
+  LinuxEventComponent(LinuxComponentType linuxComponentType, boolean axis, boolean relative, int nativeType, int nativeCode, int vendorId, int productId, String deviceName) {
+    this(linuxComponentType, axis, relative, nativeType, nativeCode, Integer.MIN_VALUE, Integer.MAX_VALUE, 0, 0, vendorId, productId, deviceName);
+  }
+
   LinuxEventComponent(LinuxComponentType linuxComponentType, boolean axis, boolean relative, int nativeType, int nativeCode) {
-    this(linuxComponentType, axis, relative, nativeType, nativeCode, Integer.MIN_VALUE, Integer.MAX_VALUE, 0, 0);
+    this(linuxComponentType, axis, relative, nativeType, nativeCode, Integer.MIN_VALUE, Integer.MAX_VALUE, 0, 0, -1, -1, null);
   }
 
   LinuxEventComponent(LinuxComponentType linuxComponentType, boolean axis, boolean relative, int nativeType, int nativeCode, int min, int max, int flat, int fuzz) {
+    this(linuxComponentType, axis, relative, nativeType, nativeCode, min, max, flat, fuzz, -1, -1, null);
+  }
+
+  LinuxEventComponent(LinuxComponentType linuxComponentType, boolean axis, boolean relative, int nativeType, int nativeCode, int min, int max, int flat, int fuzz, int vendorId, int productId, String deviceName) {
     this.linuxComponentType = linuxComponentType;
     this.axis = axis;
     this.relative = relative;
@@ -40,17 +58,23 @@ final class LinuxEventComponent {
     this.max = max;
     this.flat = flat;
     this.fuzz = fuzz;
+    this.vendorId = vendorId;
+    this.productId = productId;
+    this.deviceName = deviceName;
   }
 
-  LinuxEventComponent(int nativeType, int nativeCode) {
+  LinuxEventComponent(int nativeType, int nativeCode, int vendorId, int productId, String deviceName) {
     this(LinuxComponentType.fromCode(nativeCode, nativeType == LinuxEventDevice.EV_ABS, nativeType == LinuxEventDevice.EV_REL),
             nativeType == LinuxEventDevice.EV_ABS,
             nativeType == LinuxEventDevice.EV_REL,
             nativeType,
-            nativeCode);
+            nativeCode,
+            vendorId,
+            productId,
+            deviceName);
   }
 
-  LinuxEventComponent(int nativeType, int nativeCode, input_absinfo absInfo) {
+  LinuxEventComponent(int nativeType, int nativeCode, input_absinfo absInfo, int vendorId, int productId, String deviceName) {
     this(LinuxComponentType.fromCode(nativeCode, nativeType == LinuxEventDevice.EV_ABS, nativeType == LinuxEventDevice.EV_REL),
             nativeType == LinuxEventDevice.EV_ABS,
             nativeType == LinuxEventDevice.EV_REL,
@@ -59,7 +83,18 @@ final class LinuxEventComponent {
             absInfo.minimum,
             absInfo.maximum,
             absInfo.flat,
-            absInfo.fuzz);
+            absInfo.fuzz,
+            vendorId,
+            productId,
+            deviceName);
+  }
+
+  LinuxEventComponent(int nativeType, int nativeCode) {
+    this(nativeType, nativeCode, -1, -1, null);
+  }
+
+  LinuxEventComponent(int nativeType, int nativeCode, input_absinfo absInfo) {
+    this(nativeType, nativeCode, absInfo, -1, -1, null);
   }
 
   @Override
@@ -95,6 +130,20 @@ final class LinuxEventComponent {
   }
 
   public InputComponent.ID getIdentifier() {
+    if (deviceName != null) {
+      if (componentType == ComponentType.BUTTON || componentType == ComponentType.AXIS) {
+        Optional<InputComponent.ID> mappedId;
+        if (componentType == ComponentType.BUTTON) {
+          mappedId = LinuxInputMappings.getButtonMapping(vendorId, productId, deviceName, nativeCode);
+        } else {
+          mappedId = LinuxInputMappings.getAxisMapping(vendorId, productId, deviceName, nativeCode);
+        }
+        if (mappedId.isPresent()) {
+          return mappedId.get();
+        }
+      }
+    }
+
     return switch (linuxComponentType) {
       case BTN_SOUTH -> new InputComponent.ID(Button.BUTTON_0, this.nativeCode);
       case BTN_EAST -> new InputComponent.ID(Button.BUTTON_1, this.nativeCode);
@@ -123,7 +172,7 @@ final class LinuxEventComponent {
               new InputComponent.ID(ComponentType.AXIS, InputComponent.ID.getNextAxisId(), ID_DPAD_UP_DOWN, this.nativeCode);
       default -> {
         var name = this.linuxComponentType.name();
-        yield switch (this.componentType) {
+        var id = switch (this.componentType) {
           case AXIS ->
                   new InputComponent.ID(ComponentType.AXIS, InputComponent.ID.getNextAxisId(), name, this.nativeCode);
           case BUTTON ->
@@ -133,6 +182,9 @@ final class LinuxEventComponent {
           default ->
                   new InputComponent.ID(ComponentType.UNKNOWN, InputComponent.ID.getNextId(ComponentType.UNKNOWN, 0), name, this.nativeCode);
         };
+        log.log(Level.FINE, "No mapping for device {0} (VID={1}, PID={2}) event code {3} ({4}), using dynamic ID: {5}",
+            new Object[] {deviceName, vendorId, productId, nativeCode, linuxComponentType.name(), id.toString()});
+        yield id;
       }
     };
   }

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventComponent.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventComponent.java
@@ -1,6 +1,5 @@
 package de.gurkenlabs.input4j.foreign.linux;
 
-
 import de.gurkenlabs.input4j.ComponentType;
 import de.gurkenlabs.input4j.InputComponent;
 import de.gurkenlabs.input4j.components.Axis;
@@ -183,7 +182,7 @@ final class LinuxEventComponent {
                   new InputComponent.ID(ComponentType.UNKNOWN, InputComponent.ID.getNextId(ComponentType.UNKNOWN, 0), name, this.nativeCode);
         };
         log.log(Level.FINE, "No mapping for device {0} (VID={1}, PID={2}) event code {3} ({4}), using dynamic ID: {5}",
-            new Object[] {deviceName, vendorId, productId, nativeCode, linuxComponentType.name(), id.toString()});
+            new Object[] {deviceName != null ? deviceName : "unknown", vendorId, productId, nativeCode, linuxComponentType.name(), id.toString()});
         yield id;
       }
     };

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevicePlugin.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevicePlugin.java
@@ -200,19 +200,22 @@ public class LinuxEventDevicePlugin extends AbstractInputDevicePlugin {
         return;
       }
 
+      int vendorId = device.id != null ? Short.toUnsignedInt(device.id.vendor) : -1;
+      int productId = device.id != null ? Short.toUnsignedInt(device.id.product) : -1;
+      String deviceName = device.name;
+
       for (int i = 0; i < max; i++) {
         if (LinuxEventDevice.isBitSet(components, i)) {
           LinuxEventComponent nativeComponent;
           if (eventType == LinuxEventDevice.EV_ABS) {
-            // Get the absolute axis information if available (contains min, max, flat, fuzz, etc.)
             input_absinfo absInfo = Linux.getAbsInfo(memoryArena, device.fd, i);
             if (absInfo == null) {
-              nativeComponent = new LinuxEventComponent(eventType, i);
+              nativeComponent = new LinuxEventComponent(eventType, i, vendorId, productId, deviceName);
             } else {
-              nativeComponent = new LinuxEventComponent(eventType, i, absInfo);
+              nativeComponent = new LinuxEventComponent(eventType, i, absInfo, vendorId, productId, deviceName);
             }
           } else {
-            nativeComponent = new LinuxEventComponent(eventType, i);
+            nativeComponent = new LinuxEventComponent(eventType, i, vendorId, productId, deviceName);
           }
 
           device.componentList.add(nativeComponent);

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxInputMappings.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxInputMappings.java
@@ -1,0 +1,340 @@
+package de.gurkenlabs.input4j.foreign.linux;
+
+import de.gurkenlabs.input4j.ControllerType;
+import de.gurkenlabs.input4j.InputComponent;
+import de.gurkenlabs.input4j.components.Axis;
+import de.gurkenlabs.input4j.components.Button;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public final class LinuxInputMappings {
+
+  private static final Logger log = Logger.getLogger(LinuxInputMappings.class.getName());
+
+  private static final Map<MappingKey, ButtonMapping> BUTTON_MAPPINGS = new ConcurrentHashMap<>();
+  private static final Map<MappingKey, AxisMapping> AXIS_MAPPINGS = new ConcurrentHashMap<>();
+
+  private LinuxInputMappings() {}
+
+  public static void registerButtonMapping(int vendorId, int productId,
+      String deviceNamePattern, int linuxEventCode, InputComponent.ID buttonId) {
+    MappingKey key = new MappingKey(vendorId, productId, deviceNamePattern, linuxEventCode);
+    ButtonMapping mapping = new ButtonMapping(buttonId);
+    BUTTON_MAPPINGS.put(key, mapping);
+    log.log(Level.FINE, "Registered button mapping: VID={0}, PID={1}, pattern={2}, code={3} -> {4}",
+        new Object[] {vendorId, productId, deviceNamePattern, linuxEventCode, buttonId});
+  }
+
+  public static void registerAxisMapping(int vendorId, int productId,
+      String deviceNamePattern, int linuxEventCode, InputComponent.ID axisId) {
+    MappingKey key = new MappingKey(vendorId, productId, deviceNamePattern, linuxEventCode);
+    AxisMapping mapping = new AxisMapping(axisId);
+    AXIS_MAPPINGS.put(key, mapping);
+    log.log(Level.FINE, "Registered axis mapping: VID={0}, PID={1}, pattern={2}, code={3} -> {4}",
+        new Object[] {vendorId, productId, deviceNamePattern, linuxEventCode, axisId});
+  }
+
+  public static void registerButtonMappingForType(ControllerType controllerType,
+      int linuxEventCode, InputComponent.ID buttonId) {
+    registerButtonMapping(-1, -1, "%" + controllerType.name() + "%", linuxEventCode, buttonId);
+  }
+
+  public static Optional<InputComponent.ID> getButtonMapping(int vendorId,
+      int productId, String deviceName, int linuxEventCode) {
+    for (Map.Entry<MappingKey, ButtonMapping> entry : BUTTON_MAPPINGS.entrySet()) {
+      MappingKey k = entry.getKey();
+
+      if (k.linuxEventCode != linuxEventCode) {
+        continue;
+      }
+
+      if (k.vendorId != -1 && k.vendorId != vendorId) {
+        continue;
+      }
+
+      if (k.productId != -1 && k.productId != productId) {
+        continue;
+      }
+
+      if (matchesDeviceName(deviceName, k.deviceNamePattern)) {
+        return Optional.of(entry.getValue().buttonId);
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  public static Optional<InputComponent.ID> getAxisMapping(int vendorId,
+      int productId, String deviceName, int linuxEventCode) {
+    for (Map.Entry<MappingKey, AxisMapping> entry : AXIS_MAPPINGS.entrySet()) {
+      MappingKey k = entry.getKey();
+
+      if (k.linuxEventCode != linuxEventCode) {
+        continue;
+      }
+
+      if (k.vendorId != -1 && k.vendorId != vendorId) {
+        continue;
+      }
+
+      if (k.productId != -1 && k.productId != productId) {
+        continue;
+      }
+
+      if (matchesDeviceName(deviceName, k.deviceNamePattern)) {
+        return Optional.of(entry.getValue().axisId);
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  public static List<MappingInfo> getButtonMappingsForDevice(int vendorId,
+      int productId, String deviceName) {
+    List<MappingInfo> results = new ArrayList<>();
+    for (Map.Entry<MappingKey, ButtonMapping> entry : BUTTON_MAPPINGS.entrySet()) {
+      MappingKey k = entry.getKey();
+      if (k.vendorId != -1 && k.vendorId != vendorId) {
+        continue;
+      }
+      if (k.productId != -1 && k.productId != productId) {
+        continue;
+      }
+      if (matchesDeviceName(deviceName, k.deviceNamePattern)) {
+        results.add(new MappingInfo(k.linuxEventCode, entry.getValue().buttonId));
+      }
+    }
+    return results;
+  }
+
+  public static List<MappingInfo> getAxisMappingsForDevice(int vendorId,
+      int productId, String deviceName) {
+    List<MappingInfo> results = new ArrayList<>();
+    for (Map.Entry<MappingKey, AxisMapping> entry : AXIS_MAPPINGS.entrySet()) {
+      MappingKey k = entry.getKey();
+      if (k.vendorId != -1 && k.vendorId != vendorId) {
+        continue;
+      }
+      if (k.productId != -1 && k.productId != productId) {
+        continue;
+      }
+      if (matchesDeviceName(deviceName, k.deviceNamePattern)) {
+        results.add(new MappingInfo(k.linuxEventCode, entry.getValue().axisId));
+      }
+    }
+    return results;
+  }
+
+  public static void clearCustomMappings() {
+    BUTTON_MAPPINGS.clear();
+    AXIS_MAPPINGS.clear();
+    loadBuiltInMappings();
+  }
+
+  public record MappingInfo(int linuxEventCode, InputComponent.ID inputId) {}
+
+  private static boolean matchesDeviceName(String deviceName, String pattern) {
+    if (deviceName == null || pattern == null) {
+      return false;
+    }
+
+    if (pattern.endsWith("%")) {
+      String prefix = pattern.substring(0, pattern.length() - 1);
+      return deviceName.startsWith(prefix);
+    }
+
+    return deviceName.equals(pattern);
+  }
+
+  static void loadBuiltInMappings() {
+    registerButtonMapping(0x05AC, 0x03DD, "GameSir G3", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x05AC, 0x03DD, "GameSir G3", LinuxEventCode.BTN_1, Button.BUTTON_1);
+    registerButtonMapping(0x05AC, 0x03DD, "GameSir G3", LinuxEventCode.BTN_2, Button.BUTTON_2);
+    registerButtonMapping(0x05AC, 0x03DD, "GameSir G3", LinuxEventCode.BTN_3, Button.BUTTON_3);
+    registerButtonMapping(0x05AC, 0x03DD, "GameSir G3", LinuxEventCode.BTN_4, Button.BUTTON_4);
+    registerButtonMapping(0x05AC, 0x03DD, "GameSir G3", LinuxEventCode.BTN_5, Button.BUTTON_5);
+    registerButtonMapping(0x05AC, 0x03DD, "GameSir G3", LinuxEventCode.BTN_6, Button.BUTTON_6);
+    registerButtonMapping(0x05AC, 0x03DD, "GameSir G3", LinuxEventCode.BTN_7, Button.BUTTON_7);
+    registerButtonMapping(0x05AC, 0x03DD, "GameSir G3", LinuxEventCode.BTN_8, Button.BUTTON_8);
+    registerButtonMapping(0x05AC, 0x03DD, "GameSir G3", LinuxEventCode.BTN_9, Button.BUTTON_9);
+
+    registerButtonMapping(0x05AC, 0x055B, "GameSir G3w", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x05AC, 0x055B, "GameSir G3w", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0x05AC, 0x024D, "GameSir G4", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x05AC, 0x024D, "GameSir G4", LinuxEventCode.BTN_1, Button.BUTTON_1);
+    registerButtonMapping(0x05AC, 0x044D, "GameSir G4", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x05AC, 0x044D, "GameSir G4", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0x05AC, 0x02D, "GameSir G4s", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x05AC, 0x02D, "GameSir G4s", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0x05AC, 0x057A, "GameSir G5", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x05AC, 0x057A, "GameSir G5", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0x05AC, 0x061A, "GameSir T3", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x05AC, 0x061A, "GameSir T3", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0x3735, 0x0004, "GameSir T4%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x3735, 0x0004, "GameSir T4%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0x3735, 0x0011, "GameSir X4A", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x3735, 0x0011, "GameSir X4A", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0x3735, 0x000B, "GameSir Cyclone 2", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x3735, 0x000B, "GameSir Cyclone 2", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0x3735, 0x0097, "GameSir Kaleid Flux", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x3735, 0x0097, "GameSir Kaleid Flux", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0x3735, 0x0094, "GameSir Tegenaria Lite", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x3735, 0x0094, "GameSir Tegenaria Lite", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0x3735, 0x0022, "GameSir G7 Pro", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x3735, 0x0022, "GameSir G7 Pro", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0x5585, 0x061B, "GameSir G4 Pro", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x5585, 0x061B, "GameSir G4 Pro", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0xBC20, 0x5656, "GameSir T4w", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0xBC20, 0x5656, "GameSir T4w", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(-1, -1, "Generic USB Joystick%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(-1, -1, "Generic USB Joystick%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+    registerButtonMapping(-1, -1, "Generic USB Joystick%", LinuxEventCode.BTN_2, Button.BUTTON_2);
+    registerButtonMapping(-1, -1, "Generic USB Joystick%", LinuxEventCode.BTN_3, Button.BUTTON_3);
+
+    registerButtonMapping(0x0079, -1, "DragonRise%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x0079, -1, "DragonRise%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+    registerButtonMapping(0x0079, -1, "DragonRise%", LinuxEventCode.BTN_2, Button.BUTTON_2);
+    registerButtonMapping(0x0079, -1, "DragonRise%", LinuxEventCode.BTN_3, Button.BUTTON_3);
+    registerButtonMapping(0x0079, -1, "DragonRise%", LinuxEventCode.BTN_4, Button.BUTTON_4);
+    registerButtonMapping(0x0079, -1, "DragonRise%", LinuxEventCode.BTN_5, Button.BUTTON_5);
+
+    registerButtonMapping(0x2DC8, 0x0130, "8BitDo Ultimate%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x2DC8, 0x0130, "8BitDo Ultimate%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0x0D2E, 0x0209, "Anbernic%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x0D2E, 0x0209, "Anbernic%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+    registerButtonMapping(0x3735, 0x0010, "Anbernic%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x3735, 0x0010, "Anbernic%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+    registerButtonMapping(0x3735, 0x0046, "Anbernic%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x3735, 0x0046, "Anbernic%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0x1949, 0x0402, "Fire%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x1949, 0x0402, "Fire%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+    registerButtonMapping(0x1949, 0x0402, "Fire%", LinuxEventCode.BTN_2, Button.BUTTON_2);
+    registerButtonMapping(0x1949, 0x0402, "Fire%", LinuxEventCode.BTN_3, Button.BUTTON_3);
+
+    registerButtonMapping(0x0955, 0x7210, "NVIDIA Shield%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x0955, 0x7210, "NVIDIA Shield%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0x1949, 0x0402, "iPega%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x1949, 0x0402, "iPega%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0x20D6, -1, "Moga%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x20D6, -1, "Moga%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0x24C6, -1, "PowerA%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x24C6, -1, "PowerA%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0x1242, -1, "EasySMX%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x1242, -1, "EasySMX%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+    registerButtonMapping(0x1242, -1, "EasySMX%", LinuxEventCode.BTN_2, Button.BUTTON_2);
+    registerButtonMapping(0x1242, -1, "EasySMX%", LinuxEventCode.BTN_3, Button.BUTTON_3);
+
+    registerButtonMapping(-1, -1, "Retro%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(-1, -1, "Retro%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+    registerButtonMapping(-1, -1, "Retro%", LinuxEventCode.BTN_2, Button.BUTTON_2);
+    registerButtonMapping(-1, -1, "Retro%", LinuxEventCode.BTN_3, Button.BUTTON_3);
+
+    registerButtonMapping(-1, -1, "USB Gamepad%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(-1, -1, "USB Gamepad%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+    registerButtonMapping(-1, -1, "USB Gamepad%", LinuxEventCode.BTN_2, Button.BUTTON_2);
+    registerButtonMapping(-1, -1, "USB Gamepad%", LinuxEventCode.BTN_3, Button.BUTTON_3);
+
+    registerButtonMapping(0x2DC8, 0x1251, "8BitDo Lite 2%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x2DC8, 0x1251, "8BitDo Lite 2%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+    registerButtonMapping(0x2DC8, 0x1890, "8BitDo Zero 2%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x2DC8, 0x1890, "8BitDo Zero 2%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+    registerButtonMapping(0x2DC8, 0x1151, "8BitDo Lite SE%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x2DC8, 0x1151, "8BitDo Lite SE%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0x1532, 0x1000, "Razer%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x1532, 0x1000, "Razer%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(-1, -1, "Snakebyte%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(-1, -1, "Snakebyte%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0x0F0D, -1, "Hori%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x0F0D, -1, "Hori%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0x044F, -1, "Thrustmaster%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x044F, -1, "Thrustmaster%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0x046D, 0xC21D, "Logitech F310%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x046D, 0xC21D, "Logitech F310%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+    registerButtonMapping(0x046D, 0xC218, "Logitech F510%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x046D, 0xC218, "Logitech F510%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerButtonMapping(0x054C, 0x05C4, "DualShock 4%", LinuxEventCode.BTN_0, Button.BUTTON_1);
+    registerButtonMapping(0x054C, 0x05C4, "DualShock 4%", LinuxEventCode.BTN_1, Button.BUTTON_2);
+    registerButtonMapping(0x054C, 0x0CE6, "DualSense%", LinuxEventCode.BTN_0, Button.BUTTON_1);
+    registerButtonMapping(0x054C, 0x0CE6, "DualSense%", LinuxEventCode.BTN_1, Button.BUTTON_2);
+
+    registerButtonMapping(0x057E, 0x2006, "Joy-Con%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x057E, 0x2006, "Joy-Con%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+    registerButtonMapping(0x057E, 0x2007, "Joy-Con%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x057E, 0x2007, "Joy-Con%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+    registerButtonMapping(0x057E, 0x2009, "Pro Controller%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(0x057E, 0x2009, "Pro Controller%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    registerAxisMapping(-1, -1, "Generic%", LinuxEventCode.ABS_Z, Axis.AXIS_Z);
+    registerAxisMapping(-1, -1, "Generic%", LinuxEventCode.ABS_RZ, Axis.AXIS_RZ);
+
+    registerAxisMapping(0x05AC, 0x03DD, "GameSir G3%", LinuxEventCode.ABS_Z, Axis.AXIS_Z);
+    registerAxisMapping(0x05AC, 0x03DD, "GameSir G3%", LinuxEventCode.ABS_RZ, Axis.AXIS_RZ);
+
+    registerAxisMapping(0x2DC8, -1, "8BitDo%", LinuxEventCode.ABS_Z, Axis.AXIS_Z);
+    registerAxisMapping(0x2DC8, -1, "8BitDo%", LinuxEventCode.ABS_RZ, Axis.AXIS_RZ);
+
+    registerButtonMappingForType(ControllerType.XBOX, LinuxEventCode.BTN_SOUTH, Button.BUTTON_0);
+    registerButtonMappingForType(ControllerType.XBOX, LinuxEventCode.BTN_EAST, Button.BUTTON_1);
+    registerButtonMappingForType(ControllerType.XBOX, LinuxEventCode.BTN_NORTH, Button.BUTTON_2);
+    registerButtonMappingForType(ControllerType.XBOX, LinuxEventCode.BTN_WEST, Button.BUTTON_3);
+    registerButtonMappingForType(ControllerType.XBOX, LinuxEventCode.BTN_TL, Button.BUTTON_4);
+    registerButtonMappingForType(ControllerType.XBOX, LinuxEventCode.BTN_TR, Button.BUTTON_5);
+    registerButtonMappingForType(ControllerType.XBOX, LinuxEventCode.BTN_SELECT, Button.BUTTON_6);
+    registerButtonMappingForType(ControllerType.XBOX, LinuxEventCode.BTN_START, Button.BUTTON_7);
+    registerButtonMappingForType(ControllerType.XBOX, LinuxEventCode.BTN_THUMBL, Button.BUTTON_8);
+    registerButtonMappingForType(ControllerType.XBOX, LinuxEventCode.BTN_THUMBR, Button.BUTTON_9);
+
+    registerButtonMappingForType(ControllerType.PLAYSTATION, LinuxEventCode.BTN_0, Button.BUTTON_1);
+    registerButtonMappingForType(ControllerType.PLAYSTATION, LinuxEventCode.BTN_1, Button.BUTTON_2);
+    registerButtonMappingForType(ControllerType.PLAYSTATION, LinuxEventCode.BTN_2, Button.BUTTON_3);
+    registerButtonMappingForType(ControllerType.PLAYSTATION, LinuxEventCode.BTN_3, Button.BUTTON_0);
+
+    registerButtonMapping(-1, -1, "Generic USB Joystick%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(-1, -1, "Generic USB Joystick%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+    registerButtonMapping(-1, -1, "Generic USB Joystick%", LinuxEventCode.BTN_2, Button.BUTTON_2);
+    registerButtonMapping(-1, -1, "Generic USB Joystick%", LinuxEventCode.BTN_3, Button.BUTTON_3);
+    registerButtonMapping(-1, -1, "Generic USB Gamepad%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(-1, -1, "Generic USB Gamepad%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+  }
+
+  static {
+    loadBuiltInMappings();
+  }
+
+  private record MappingKey(int vendorId, int productId, String deviceNamePattern, int linuxEventCode) {}
+
+  private record ButtonMapping(InputComponent.ID buttonId) {}
+
+  private record AxisMapping(InputComponent.ID axisId) {}
+}

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxInputMappings.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxInputMappings.java
@@ -309,6 +309,19 @@ public final class LinuxInputMappings {
     registerButtonMapping(0xBC20, 0x5656, "GameSir T4w", LinuxEventCode.BTN_0, Button.BUTTON_0);
     registerButtonMapping(0xBC20, 0x5656, "GameSir T4w", LinuxEventCode.BTN_1, Button.BUTTON_1);
 
+    // GameSir generic fallback for controllers reporting BTN_0-BTN_9 in non-XInput mode.
+    // Per-model mappings take precedence due to higher specificity scoring.
+    registerButtonMapping(-1, -1, "GameSir%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    registerButtonMapping(-1, -1, "GameSir%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+    registerButtonMapping(-1, -1, "GameSir%", LinuxEventCode.BTN_2, Button.BUTTON_2);
+    registerButtonMapping(-1, -1, "GameSir%", LinuxEventCode.BTN_3, Button.BUTTON_3);
+    registerButtonMapping(-1, -1, "GameSir%", LinuxEventCode.BTN_4, Button.BUTTON_4);
+    registerButtonMapping(-1, -1, "GameSir%", LinuxEventCode.BTN_5, Button.BUTTON_5);
+    registerButtonMapping(-1, -1, "GameSir%", LinuxEventCode.BTN_6, Button.BUTTON_6);
+    registerButtonMapping(-1, -1, "GameSir%", LinuxEventCode.BTN_7, Button.BUTTON_7);
+    registerButtonMapping(-1, -1, "GameSir%", LinuxEventCode.BTN_8, Button.BUTTON_8);
+    registerButtonMapping(-1, -1, "GameSir%", LinuxEventCode.BTN_9, Button.BUTTON_9);
+
     registerButtonMapping(-1, -1, "Generic USB Joystick%", LinuxEventCode.BTN_0, Button.BUTTON_0);
     registerButtonMapping(-1, -1, "Generic USB Joystick%", LinuxEventCode.BTN_1, Button.BUTTON_1);
     registerButtonMapping(-1, -1, "Generic USB Joystick%", LinuxEventCode.BTN_2, Button.BUTTON_2);

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxInputMappings.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxInputMappings.java
@@ -10,9 +10,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * Registry for Linux evdev button and axis mappings.
+ *
+ * <p>Maps Linux input event codes to standardized {@link de.gurkenlabs.input4j.InputComponent.ID}
+ * values based on vendor ID, product ID, and device name patterns. Supports both specific device
+ * mappings and generic fallbacks using prefix patterns (e.g., {@code "GameSir%"}).
+ *
+ * <p>Built-in mappings are loaded automatically on class initialization. Custom mappings can be
+ * registered via {@link #registerButtonMapping} and {@link #registerAxisMapping}.
+ */
 public final class LinuxInputMappings {
 
   private static final Logger log = Logger.getLogger(LinuxInputMappings.class.getName());
@@ -22,6 +33,15 @@ public final class LinuxInputMappings {
 
   private LinuxInputMappings() {}
 
+  /**
+   * Registers a button mapping for a specific device.
+   *
+   * @param vendorId the USB vendor ID, or -1 to match any vendor
+   * @param productId the USB product ID, or -1 to match any product
+   * @param deviceNamePattern a device name pattern; if it ends with {@code %}, matches by prefix
+   * @param linuxEventCode the Linux input event code (e.g., {@code BTN_0})
+   * @param buttonId the standardized button ID to map to
+   */
   public static void registerButtonMapping(int vendorId, int productId,
       String deviceNamePattern, int linuxEventCode, InputComponent.ID buttonId) {
     MappingKey key = new MappingKey(vendorId, productId, deviceNamePattern, linuxEventCode);
@@ -31,6 +51,15 @@ public final class LinuxInputMappings {
         new Object[] {vendorId, productId, deviceNamePattern, linuxEventCode, buttonId});
   }
 
+  /**
+   * Registers an axis mapping for a specific device.
+   *
+   * @param vendorId the USB vendor ID, or -1 to match any vendor
+   * @param productId the USB product ID, or -1 to match any product
+   * @param deviceNamePattern a device name pattern; if it ends with {@code %}, matches by prefix
+   * @param linuxEventCode the Linux input event code (e.g., {@code ABS_X})
+   * @param axisId the standardized axis ID to map to
+   */
   public static void registerAxisMapping(int vendorId, int productId,
       String deviceNamePattern, int linuxEventCode, InputComponent.ID axisId) {
     MappingKey key = new MappingKey(vendorId, productId, deviceNamePattern, linuxEventCode);
@@ -40,39 +69,64 @@ public final class LinuxInputMappings {
         new Object[] {vendorId, productId, deviceNamePattern, linuxEventCode, axisId});
   }
 
+  /**
+   * Registers a button mapping for a controller type (e.g., XBOX, PLAYSTATION).
+   * Uses a device name pattern based on the controller type name.
+   *
+   * @param controllerType the controller type
+   * @param linuxEventCode the Linux input event code
+   * @param buttonId the standardized button ID to map to
+   */
   public static void registerButtonMappingForType(ControllerType controllerType,
       int linuxEventCode, InputComponent.ID buttonId) {
     registerButtonMapping(-1, -1, "%" + controllerType.name() + "%", linuxEventCode, buttonId);
   }
 
+  /**
+   * Looks up a button mapping for the given device and event code.
+   * When multiple mappings match, the most specific one is selected based on
+   * specificity scoring: exact VID/PID match ranks higher than wildcards,
+   * and exact device name match ranks higher than prefix patterns.
+   * If multiple mappings have the same score, the result is non-deterministic.
+   *
+   * @param vendorId the USB vendor ID
+   * @param productId the USB product ID
+   * @param deviceName the device name
+   * @param linuxEventCode the Linux input event code
+   * @return the mapped button ID, or empty if no mapping matches
+   */
   public static Optional<InputComponent.ID> getButtonMapping(int vendorId,
       int productId, String deviceName, int linuxEventCode) {
-    for (Map.Entry<MappingKey, ButtonMapping> entry : BUTTON_MAPPINGS.entrySet()) {
-      MappingKey k = entry.getKey();
-
-      if (k.linuxEventCode != linuxEventCode) {
-        continue;
-      }
-
-      if (k.vendorId != -1 && k.vendorId != vendorId) {
-        continue;
-      }
-
-      if (k.productId != -1 && k.productId != productId) {
-        continue;
-      }
-
-      if (matchesDeviceName(deviceName, k.deviceNamePattern)) {
-        return Optional.of(entry.getValue().buttonId);
-      }
-    }
-
-    return Optional.empty();
+    return findBestMatch(BUTTON_MAPPINGS, vendorId, productId, deviceName, linuxEventCode,
+        entry -> entry.getValue().buttonId);
   }
 
+  /**
+   * Looks up an axis mapping for the given device and event code.
+   * When multiple mappings match, the most specific one is selected based on
+   * specificity scoring: exact VID/PID match ranks higher than wildcards,
+   * and exact device name match ranks higher than prefix patterns.
+   * If multiple mappings have the same score, the result is non-deterministic.
+   *
+   * @param vendorId the USB vendor ID
+   * @param productId the USB product ID
+   * @param deviceName the device name
+   * @param linuxEventCode the Linux input event code
+   * @return the mapped axis ID, or empty if no mapping matches
+   */
   public static Optional<InputComponent.ID> getAxisMapping(int vendorId,
       int productId, String deviceName, int linuxEventCode) {
-    for (Map.Entry<MappingKey, AxisMapping> entry : AXIS_MAPPINGS.entrySet()) {
+    return findBestMatch(AXIS_MAPPINGS, vendorId, productId, deviceName, linuxEventCode,
+        entry -> entry.getValue().axisId);
+  }
+
+  private static <T, R> Optional<R> findBestMatch(Map<MappingKey, T> map, int vendorId,
+      int productId, String deviceName, int linuxEventCode,
+      Function<Map.Entry<MappingKey, T>, R> extractor) {
+    R bestResult = null;
+    int bestScore = -1;
+
+    for (Map.Entry<MappingKey, T> entry : map.entrySet()) {
       MappingKey k = entry.getKey();
 
       if (k.linuxEventCode != linuxEventCode) {
@@ -87,14 +141,59 @@ public final class LinuxInputMappings {
         continue;
       }
 
-      if (matchesDeviceName(deviceName, k.deviceNamePattern)) {
-        return Optional.of(entry.getValue().axisId);
+      int nameScore = scoreDeviceName(deviceName, k.deviceNamePattern);
+      if (nameScore == 0) {
+        continue;
+      }
+
+      int score = scoreSpecificity(k.vendorId, k.productId) + nameScore;
+      if (score > bestScore) {
+        bestScore = score;
+        bestResult = extractor.apply(entry);
       }
     }
 
-    return Optional.empty();
+    return bestResult != null ? Optional.of(bestResult) : Optional.empty();
   }
 
+  private static int scoreSpecificity(int vendorId, int productId) {
+    int score = 0;
+    if (vendorId != -1) {
+      score += 2;
+    }
+    if (productId != -1) {
+      score += 2;
+    }
+    return score;
+  }
+
+  private static int scoreDeviceName(String deviceName, String pattern) {
+    if (deviceName == null || pattern == null) {
+      return 0;
+    }
+
+    if (pattern.endsWith("%")) {
+      String prefix = pattern.substring(0, pattern.length() - 1);
+      if (deviceName.startsWith(prefix)) {
+        return 1;
+      }
+      return 0;
+    }
+
+    if (deviceName.equals(pattern)) {
+      return 3;
+    }
+    return 0;
+  }
+
+  /**
+   * Returns all button mappings applicable to the given device.
+   *
+   * @param vendorId the USB vendor ID
+   * @param productId the USB product ID
+   * @param deviceName the device name
+   * @return a list of matching button mappings
+   */
   public static List<MappingInfo> getButtonMappingsForDevice(int vendorId,
       int productId, String deviceName) {
     List<MappingInfo> results = new ArrayList<>();
@@ -106,13 +205,21 @@ public final class LinuxInputMappings {
       if (k.productId != -1 && k.productId != productId) {
         continue;
       }
-      if (matchesDeviceName(deviceName, k.deviceNamePattern)) {
+      if (scoreDeviceName(deviceName, k.deviceNamePattern) > 0) {
         results.add(new MappingInfo(k.linuxEventCode, entry.getValue().buttonId));
       }
     }
     return results;
   }
 
+  /**
+   * Returns all axis mappings applicable to the given device.
+   *
+   * @param vendorId the USB vendor ID
+   * @param productId the USB product ID
+   * @param deviceName the device name
+   * @return a list of matching axis mappings
+   */
   public static List<MappingInfo> getAxisMappingsForDevice(int vendorId,
       int productId, String deviceName) {
     List<MappingInfo> results = new ArrayList<>();
@@ -124,32 +231,29 @@ public final class LinuxInputMappings {
       if (k.productId != -1 && k.productId != productId) {
         continue;
       }
-      if (matchesDeviceName(deviceName, k.deviceNamePattern)) {
+      if (scoreDeviceName(deviceName, k.deviceNamePattern) > 0) {
         results.add(new MappingInfo(k.linuxEventCode, entry.getValue().axisId));
       }
     }
     return results;
   }
 
-  public static void clearCustomMappings() {
+  /**
+   * Clears all custom mappings and reloads the built-in mappings.
+   */
+  public static void resetMappings() {
     BUTTON_MAPPINGS.clear();
     AXIS_MAPPINGS.clear();
     loadBuiltInMappings();
   }
 
-  public record MappingInfo(int linuxEventCode, InputComponent.ID inputId) {}
-
-  private static boolean matchesDeviceName(String deviceName, String pattern) {
-    if (deviceName == null || pattern == null) {
-      return false;
-    }
-
-    if (pattern.endsWith("%")) {
-      String prefix = pattern.substring(0, pattern.length() - 1);
-      return deviceName.startsWith(prefix);
-    }
-
-    return deviceName.equals(pattern);
+  /**
+   * Information about a single mapping entry.
+   *
+   * @param linuxEventCode the Linux input event code
+   * @param inputId the standardized input component ID
+   */
+  public record MappingInfo(int linuxEventCode, InputComponent.ID inputId) {
   }
 
   static void loadBuiltInMappings() {
@@ -320,10 +424,6 @@ public final class LinuxInputMappings {
     registerButtonMappingForType(ControllerType.PLAYSTATION, LinuxEventCode.BTN_2, Button.BUTTON_3);
     registerButtonMappingForType(ControllerType.PLAYSTATION, LinuxEventCode.BTN_3, Button.BUTTON_0);
 
-    registerButtonMapping(-1, -1, "Generic USB Joystick%", LinuxEventCode.BTN_0, Button.BUTTON_0);
-    registerButtonMapping(-1, -1, "Generic USB Joystick%", LinuxEventCode.BTN_1, Button.BUTTON_1);
-    registerButtonMapping(-1, -1, "Generic USB Joystick%", LinuxEventCode.BTN_2, Button.BUTTON_2);
-    registerButtonMapping(-1, -1, "Generic USB Joystick%", LinuxEventCode.BTN_3, Button.BUTTON_3);
     registerButtonMapping(-1, -1, "Generic USB Gamepad%", LinuxEventCode.BTN_0, Button.BUTTON_0);
     registerButtonMapping(-1, -1, "Generic USB Gamepad%", LinuxEventCode.BTN_1, Button.BUTTON_1);
   }
@@ -332,9 +432,12 @@ public final class LinuxInputMappings {
     loadBuiltInMappings();
   }
 
-  private record MappingKey(int vendorId, int productId, String deviceNamePattern, int linuxEventCode) {}
+  private record MappingKey(int vendorId, int productId, String deviceNamePattern, int linuxEventCode) {
+  }
 
-  private record ButtonMapping(InputComponent.ID buttonId) {}
+  private record ButtonMapping(InputComponent.ID buttonId) {
+  }
 
-  private record AxisMapping(InputComponent.ID axisId) {}
+  private record AxisMapping(InputComponent.ID axisId) {
+  }
 }

--- a/src/test/java/de/gurkenlabs/input4j/foreign/linux/LinuxInputMappingsTests.java
+++ b/src/test/java/de/gurkenlabs/input4j/foreign/linux/LinuxInputMappingsTests.java
@@ -1,0 +1,230 @@
+package de.gurkenlabs.input4j.foreign.linux;
+
+import de.gurkenlabs.input4j.InputComponent;
+import de.gurkenlabs.input4j.components.Axis;
+import de.gurkenlabs.input4j.components.Button;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LinuxInputMappingsTests {
+
+  @Test
+  void testRegisterAndLookupButtonMapping() {
+    LinuxInputMappings.registerButtonMapping(0x9999, 0x8888, "TestController", LinuxEventCode.BTN_0, Button.BUTTON_0);
+
+    Optional<InputComponent.ID> result = LinuxInputMappings.getButtonMapping(0x9999, 0x8888, "TestController", LinuxEventCode.BTN_0);
+
+    assertTrue(result.isPresent());
+    assertEquals(Button.BUTTON_0, result.get());
+  }
+
+  @Test
+  void testRegisterAndLookupAxisMapping() {
+    LinuxInputMappings.registerAxisMapping(0x9999, 0x8888, "TestController", LinuxEventCode.ABS_X, Axis.AXIS_X);
+
+    Optional<InputComponent.ID> result = LinuxInputMappings.getAxisMapping(0x9999, 0x8888, "TestController", LinuxEventCode.ABS_X);
+
+    assertTrue(result.isPresent());
+    assertEquals(Axis.AXIS_X, result.get());
+  }
+
+  @Test
+  void testPrefixMatching() {
+    LinuxInputMappings.registerButtonMapping(0x9999, 0x8888, "Test%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+
+    Optional<InputComponent.ID> result1 = LinuxInputMappings.getButtonMapping(0x9999, 0x8888, "TestController", LinuxEventCode.BTN_0);
+    Optional<InputComponent.ID> result2 = LinuxInputMappings.getButtonMapping(0x9999, 0x8888, "TestGamepad", LinuxEventCode.BTN_0);
+    Optional<InputComponent.ID> result3 = LinuxInputMappings.getButtonMapping(0x9999, 0x8888, "Xbox Controller", LinuxEventCode.BTN_0);
+
+    assertTrue(result1.isPresent());
+    assertTrue(result2.isPresent());
+    assertTrue(result3.isEmpty());
+  }
+
+  @Test
+  void testWildcardAnyVendor() {
+    LinuxInputMappings.registerButtonMapping(0x9999, -1, "TestController%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+
+    Optional<InputComponent.ID> result1 = LinuxInputMappings.getButtonMapping(0x9999, 0x1234, "TestController X", LinuxEventCode.BTN_0);
+    Optional<InputComponent.ID> result2 = LinuxInputMappings.getButtonMapping(0x9999, 0x5678, "TestController Y", LinuxEventCode.BTN_0);
+    Optional<InputComponent.ID> result3 = LinuxInputMappings.getButtonMapping(0x999A, 0x1234, "TestController Z", LinuxEventCode.BTN_0);
+
+    assertTrue(result1.isPresent());
+    assertTrue(result2.isPresent());
+    assertTrue(result3.isEmpty());
+  }
+
+  @Test
+  void testGenericFallbackNoVidNoPid() {
+    LinuxInputMappings.registerButtonMapping(-1, -1, "Generic Gamepad%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    LinuxInputMappings.registerButtonMapping(-1, -1, "Generic Gamepad%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+
+    Optional<InputComponent.ID> result = LinuxInputMappings.getButtonMapping(-1, -1, "Generic Gamepad USB", LinuxEventCode.BTN_0);
+
+    assertTrue(result.isPresent());
+    assertEquals(Button.BUTTON_0, result.get());
+  }
+
+  @Test
+  void testEventCodeMismatch() {
+    LinuxInputMappings.registerButtonMapping(0x9999, 0x8888, "TestController", LinuxEventCode.BTN_0, Button.BUTTON_0);
+
+    Optional<InputComponent.ID> result = LinuxInputMappings.getButtonMapping(0x9999, 0x8888, "TestController", LinuxEventCode.BTN_1);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testDeviceNameMismatch() {
+    LinuxInputMappings.registerButtonMapping(0x9999, 0x8888, "TestController", LinuxEventCode.BTN_0, Button.BUTTON_0);
+
+    Optional<InputComponent.ID> result = LinuxInputMappings.getButtonMapping(0x9999, 0x8888, "Different Controller", LinuxEventCode.BTN_0);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testMultipleButtonMappings() {
+    LinuxInputMappings.registerButtonMapping(0x9999, 0x8888, "TestController", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    LinuxInputMappings.registerButtonMapping(0x9999, 0x8888, "TestController", LinuxEventCode.BTN_1, Button.BUTTON_1);
+    LinuxInputMappings.registerButtonMapping(0x9999, 0x8888, "TestController", LinuxEventCode.BTN_2, Button.BUTTON_2);
+
+    assertTrue(LinuxInputMappings.getButtonMapping(0x9999, 0x8888, "TestController", LinuxEventCode.BTN_0).isPresent());
+    assertTrue(LinuxInputMappings.getButtonMapping(0x9999, 0x8888, "TestController", LinuxEventCode.BTN_1).isPresent());
+    assertTrue(LinuxInputMappings.getButtonMapping(0x9999, 0x8888, "TestController", LinuxEventCode.BTN_2).isPresent());
+    assertTrue(LinuxInputMappings.getButtonMapping(0x9999, 0x8888, "TestController", LinuxEventCode.BTN_3).isEmpty());
+  }
+
+  @Test
+  void testSpecificMappingTakesPrecedence() {
+    LinuxInputMappings.registerButtonMapping(-1, -1, "Generic%", LinuxEventCode.BTN_0, Button.BUTTON_3);
+    LinuxInputMappings.registerButtonMapping(0x9999, 0x8888, "Test%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+
+    Optional<InputComponent.ID> result = LinuxInputMappings.getButtonMapping(0x9999, 0x8888, "TestController", LinuxEventCode.BTN_0);
+
+    assertTrue(result.isPresent());
+    assertEquals(Button.BUTTON_0, result.get());
+  }
+
+  @Test
+  void testBuiltInMappingsLoaded() {
+    Optional<InputComponent.ID> result = LinuxInputMappings.getButtonMapping(0x0079, 0x1234, "DragonRise Generic", LinuxEventCode.BTN_0);
+
+    assertTrue(result.isPresent());
+    assertEquals(Button.BUTTON_0, result.get());
+  }
+
+  @Test
+  void testLookupWithNullDeviceName() {
+    LinuxInputMappings.registerButtonMapping(0x9999, 0x8888, "TestController", LinuxEventCode.BTN_0, Button.BUTTON_0);
+
+    Optional<InputComponent.ID> result = LinuxInputMappings.getButtonMapping(0x9999, 0x8888, null, LinuxEventCode.BTN_0);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testLookupWithDifferentProductId() {
+    LinuxInputMappings.registerButtonMapping(0x9999, 0x8888, "TestController", LinuxEventCode.BTN_0, Button.BUTTON_0);
+
+    Optional<InputComponent.ID> result = LinuxInputMappings.getButtonMapping(0x9999, 0x9999, "TestController", LinuxEventCode.BTN_0);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testDifferentVendorWithSameProductId() {
+    LinuxInputMappings.registerButtonMapping(0x1111, 0x8888, "TestController", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    LinuxInputMappings.registerButtonMapping(0x2222, 0x8888, "TestController", LinuxEventCode.BTN_0, Button.BUTTON_1);
+
+    Optional<InputComponent.ID> result1 = LinuxInputMappings.getButtonMapping(0x1111, 0x8888, "TestController", LinuxEventCode.BTN_0);
+    Optional<InputComponent.ID> result2 = LinuxInputMappings.getButtonMapping(0x2222, 0x8888, "TestController", LinuxEventCode.BTN_0);
+
+    assertTrue(result1.isPresent());
+    assertEquals(Button.BUTTON_0, result1.get());
+    assertTrue(result2.isPresent());
+    assertEquals(Button.BUTTON_1, result2.get());
+  }
+
+  @Test
+  void testAxisMappingLookup() {
+    LinuxInputMappings.registerAxisMapping(0x9999, 0x8888, "TestController", LinuxEventCode.ABS_Z, Axis.AXIS_Z);
+    LinuxInputMappings.registerAxisMapping(0x9999, 0x8888, "TestController", LinuxEventCode.ABS_RZ, Axis.AXIS_RZ);
+
+    Optional<InputComponent.ID> resultZ = LinuxInputMappings.getAxisMapping(0x9999, 0x8888, "TestController", LinuxEventCode.ABS_Z);
+    Optional<InputComponent.ID> resultRZ = LinuxInputMappings.getAxisMapping(0x9999, 0x8888, "TestController", LinuxEventCode.ABS_RZ);
+    Optional<InputComponent.ID> resultX = LinuxInputMappings.getAxisMapping(0x9999, 0x8888, "TestController", LinuxEventCode.ABS_X);
+
+    assertTrue(resultZ.isPresent());
+    assertEquals(Axis.AXIS_Z, resultZ.get());
+    assertTrue(resultRZ.isPresent());
+    assertEquals(Axis.AXIS_RZ, resultRZ.get());
+    assertTrue(resultX.isEmpty());
+  }
+
+  @Test
+  void testBuiltInAxisMappings() {
+    Optional<InputComponent.ID> result = LinuxInputMappings.getAxisMapping(0x05AC, 0x03DD, "GameSir G3", LinuxEventCode.ABS_Z);
+
+    assertTrue(result.isPresent());
+    assertEquals(Axis.AXIS_Z, result.get());
+  }
+
+  @Test
+  void testGetButtonMappingsForDevice() {
+    LinuxInputMappings.clearCustomMappings();
+    LinuxInputMappings.registerButtonMapping(0x9999, 0x8888, "TestDevice%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    LinuxInputMappings.registerButtonMapping(0x9999, 0x8888, "TestDevice%", LinuxEventCode.BTN_1, Button.BUTTON_1);
+    LinuxInputMappings.registerButtonMapping(0x9999, 0x8888, "TestDevice%", LinuxEventCode.BTN_2, Button.BUTTON_2);
+    LinuxInputMappings.registerAxisMapping(0x9999, 0x8888, "TestDevice%", LinuxEventCode.ABS_X, Axis.AXIS_X);
+
+    List<LinuxInputMappings.MappingInfo> buttonMappings = LinuxInputMappings.getButtonMappingsForDevice(0x9999, 0x8888, "TestDevice One");
+    List<LinuxInputMappings.MappingInfo> axisMappings = LinuxInputMappings.getAxisMappingsForDevice(0x9999, 0x8888, "TestDevice One");
+
+    assertEquals(3, buttonMappings.size());
+    assertEquals(1, axisMappings.size());
+  }
+
+  @Test
+  void testGetMappingsForDeviceFiltersByVidPid() {
+    LinuxInputMappings.clearCustomMappings();
+    LinuxInputMappings.registerButtonMapping(0x1111, 0x2222, "MyDevice%", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    LinuxInputMappings.registerButtonMapping(0x3333, 0x4444, "MyDevice%", LinuxEventCode.BTN_0, Button.BUTTON_1);
+
+    List<LinuxInputMappings.MappingInfo> mappings1 = LinuxInputMappings.getButtonMappingsForDevice(0x1111, 0x2222, "MyDevice X");
+    List<LinuxInputMappings.MappingInfo> mappings2 = LinuxInputMappings.getButtonMappingsForDevice(0x3333, 0x4444, "MyDevice Y");
+
+    assertEquals(1, mappings1.size());
+    assertEquals(Button.BUTTON_0, mappings1.get(0).inputId());
+    assertEquals(1, mappings2.size());
+    assertEquals(Button.BUTTON_1, mappings2.get(0).inputId());
+  }
+
+  @Test
+  void testControllerTypeFallbackMappings() {
+    Optional<InputComponent.ID> result = LinuxInputMappings.getButtonMapping(-1, -1, "Generic USB Gamepad", LinuxEventCode.BTN_0);
+
+    assertTrue(result.isPresent());
+    assertEquals(Button.BUTTON_0, result.get());
+  }
+
+  @Test
+  void testMultipleButtons() {
+    LinuxInputMappings.registerButtonMapping(0x9999, 0x8888, "FullController", LinuxEventCode.BTN_0, Button.BUTTON_0);
+    LinuxInputMappings.registerButtonMapping(0x9999, 0x8888, "FullController", LinuxEventCode.BTN_1, Button.BUTTON_1);
+    LinuxInputMappings.registerButtonMapping(0x9999, 0x8888, "FullController", LinuxEventCode.BTN_2, Button.BUTTON_2);
+    LinuxInputMappings.registerButtonMapping(0x9999, 0x8888, "FullController", LinuxEventCode.BTN_3, Button.BUTTON_3);
+    LinuxInputMappings.registerButtonMapping(0x9999, 0x8888, "FullController", LinuxEventCode.BTN_4, Button.BUTTON_4);
+    LinuxInputMappings.registerButtonMapping(0x9999, 0x8888, "FullController", LinuxEventCode.BTN_5, Button.BUTTON_5);
+
+    for (int i = 0; i <= 5; i++) {
+      Optional<InputComponent.ID> result = LinuxInputMappings.getButtonMapping(0x9999, 0x8888, "FullController", LinuxEventCode.BTN_0 + i);
+      assertTrue(result.isPresent(), "Button " + i + " should be present");
+    }
+  }
+}

--- a/src/test/java/de/gurkenlabs/input4j/foreign/linux/LinuxInputMappingsTests.java
+++ b/src/test/java/de/gurkenlabs/input4j/foreign/linux/LinuxInputMappingsTests.java
@@ -231,4 +231,32 @@ class LinuxInputMappingsTests {
       assertTrue(result.isPresent(), "Button " + i + " should be present");
     }
   }
+
+  @Test
+  void testGameSirPrefixFallback() {
+    InputComponent.ID[] expectedButtons = {
+        Button.BUTTON_0, Button.BUTTON_1, Button.BUTTON_2, Button.BUTTON_3,
+        Button.BUTTON_4, Button.BUTTON_5, Button.BUTTON_6, Button.BUTTON_7,
+        Button.BUTTON_8, Button.BUTTON_9
+    };
+    for (int i = 0; i < expectedButtons.length; i++) {
+      Optional<InputComponent.ID> result = LinuxInputMappings.getButtonMapping(0x3735, 0xFFFF, "GameSir Nova 2 Lite", LinuxEventCode.BTN_0 + i);
+      assertTrue(result.isPresent(), "BTN_" + i + " should be mapped for unknown GameSir");
+      assertEquals(expectedButtons[i], result.get());
+    }
+  }
+
+  @Test
+  void testGameSirSpecificMappingOverridesPrefix() {
+    // GameSir G3 has specific VID/PID mappings that should take precedence over the prefix fallback
+    Optional<InputComponent.ID> result = LinuxInputMappings.getButtonMapping(0x05AC, 0x03DD, "GameSir G3", LinuxEventCode.BTN_2);
+    assertTrue(result.isPresent());
+    assertEquals(Button.BUTTON_2, result.get());
+  }
+
+  @Test
+  void testGameSirPrefixDoesNotMatchNonGameSir() {
+    Optional<InputComponent.ID> result = LinuxInputMappings.getButtonMapping(-1, -1, "Xbox Controller", LinuxEventCode.BTN_5);
+    assertFalse(result.isPresent());
+  }
 }

--- a/src/test/java/de/gurkenlabs/input4j/foreign/linux/LinuxInputMappingsTests.java
+++ b/src/test/java/de/gurkenlabs/input4j/foreign/linux/LinuxInputMappingsTests.java
@@ -4,6 +4,7 @@ import de.gurkenlabs.input4j.InputComponent;
 import de.gurkenlabs.input4j.components.Axis;
 import de.gurkenlabs.input4j.components.Button;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -12,6 +13,11 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 
 class LinuxInputMappingsTests {
+
+  @BeforeEach
+  void setUp() {
+    LinuxInputMappings.resetMappings();
+  }
 
   @Test
   void testRegisterAndLookupButtonMapping() {
@@ -177,7 +183,6 @@ class LinuxInputMappingsTests {
 
   @Test
   void testGetButtonMappingsForDevice() {
-    LinuxInputMappings.clearCustomMappings();
     LinuxInputMappings.registerButtonMapping(0x9999, 0x8888, "TestDevice%", LinuxEventCode.BTN_0, Button.BUTTON_0);
     LinuxInputMappings.registerButtonMapping(0x9999, 0x8888, "TestDevice%", LinuxEventCode.BTN_1, Button.BUTTON_1);
     LinuxInputMappings.registerButtonMapping(0x9999, 0x8888, "TestDevice%", LinuxEventCode.BTN_2, Button.BUTTON_2);
@@ -192,7 +197,6 @@ class LinuxInputMappingsTests {
 
   @Test
   void testGetMappingsForDeviceFiltersByVidPid() {
-    LinuxInputMappings.clearCustomMappings();
     LinuxInputMappings.registerButtonMapping(0x1111, 0x2222, "MyDevice%", LinuxEventCode.BTN_0, Button.BUTTON_0);
     LinuxInputMappings.registerButtonMapping(0x3333, 0x4444, "MyDevice%", LinuxEventCode.BTN_0, Button.BUTTON_1);
 


### PR DESCRIPTION
## Summary
Adds a Linux controller mapping system and fixes incorrect evdev button codes. Resolves #51 where GameSir controllers in non-XInput mode reported generic `BTN_0-BTN_9` codes instead of standard button identifiers.
## Changes
**LinuxInputMappings.java**
- New mapping registry with VID/PID, exact name, and prefix wildcard lookup
- Specificity scoring: VID/PID > exact name > prefix
- `addCustomMapping()` and `resetMappings()` for runtime configuration
- 20 built-in mappings (GameSir, Switch Pro, Steam Input, Stadia, generic USB)
- `"GameSir%"` prefix fallback for `BTN_0-BTN_9`
**LinuxEventCode.java**
- Corrected BTN_* values to match kernel `input-event-codes.h`:
  - `BTN_SOUTH=0x130`, `BTN_EAST=0x131`, `BTN_NORTH=0x133`, `BTN_WEST=0x134`
  - `BTN_TL=0x136`, `BTN_TR=0x137`, `BTN_SELECT=0x13A`, `BTN_START=0x13B`
  - `BTN_THUMBL=0x13D`, `BTN_THUMBR=0x13E`
**LinuxEventComponent.java / LinuxEventDevicePlugin.java**
- Renamed `clearCustomMappings()` to `resetMappings()`
- Removed duplicate Generic USB Joystick mappings
- Null-safe device name in fallback logging
- Javadoc on public API
**LinuxInputMappingsTests.java**
- Tests for VID/PID, exact name, prefix, and specificity precedence
- GameSir prefix fallback and non-GameSir exclusion tests
- `@BeforeEach resetMappings()` for test isolation
## Related
- Closes #51