### PR TITLE
Fix/linux rumble support

### DIFF
--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/Linux.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/Linux.java
@@ -62,7 +62,8 @@ class Linux {
   static final int FF_RAMP = 0x57;
   static final int FF_EFFECT_MIN = 0x50;
   static final int FF_EFFECT_MAX = 0x5f;
-  static final int FF_CNT = FF_EFFECT_MAX + 1;
+  static final int FF_MAX = 0x7f;
+  static final int FF_CNT = FF_MAX + 1;
 
   static final int FF_STATUS_STOPPED = 0x00;
   static final int FF_STATUS_PLAYING = 0x01;

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/Linux.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/Linux.java
@@ -61,7 +61,7 @@ class Linux {
   static final int FF_INERTIA = 0x56;
   static final int FF_RAMP = 0x57;
   static final int FF_EFFECT_MIN = 0x50;
-  static final int FF_EFFECT_MAX = 0x5f;
+  static final int FF_EFFECT_MAX = 0x57;
   static final int FF_MAX = 0x7f;
   static final int FF_CNT = FF_MAX + 1;
 
@@ -70,6 +70,7 @@ class Linux {
   static final int FF_STATUS_MAX = 0x01;
 
   static final int FF_GAIN = 0x60;
+  static final int FF_SINE = 0x5a;
 
   private static int EVIOCGKEY(int len) {
     return _IOC(_IOC_READ, 'E', 0x18, len);

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevice.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevice.java
@@ -27,7 +27,6 @@ class LinuxEventDevice {
   static final int KEY_MAX = 0x2ff;
   static final int REL_MAX = 0x0f;
   static final int ABS_MAX = 0x3f;
-  static final int FF_MAX = 0x7f;
 
   private static final Logger log = Logger.getLogger(LinuxEventDevice.class.getName());
   final String filename;
@@ -51,6 +50,14 @@ class LinuxEventDevice {
    * the rumble effect type.
    */
   final boolean supportsRumble;
+
+  /**
+   * Whether the device reports FF_SINE (0x5a) capability via EVIOCGBIT(EV_FF).
+   * Used as a fallback when FF_RUMBLE is not available — the kernel can emulate
+   * rumble via FF_PERIODIC/FF_SINE, but some older drivers only expose FF_SINE
+   * without the kernel's auto-emulation of FF_RUMBLE.
+   */
+  final boolean supportsSine;
 
   /**
    * Whether the device reports FF_GAIN (0x60) capability via EVIOCGBIT(EV_FF).
@@ -81,6 +88,7 @@ class LinuxEventDevice {
       this.version = 0;
       this.supportsForceFeedback = false;
       this.supportsRumble = false;
+      this.supportsSine = false;
       this.supportsGain = false;
       this.maxEffects = 0;
     } else {
@@ -91,13 +99,15 @@ class LinuxEventDevice {
       byte[] ffBits = Linux.getBits(memoryArena, EV_FF, this.fd);
       if (ffBits != null) {
         this.supportsRumble = isBitSet(ffBits, Linux.FF_RUMBLE);
+        this.supportsSine = isBitSet(ffBits, Linux.FF_SINE);
         this.supportsGain = isBitSet(ffBits, Linux.FF_GAIN);
       } else {
         this.supportsRumble = false;
+        this.supportsSine = false;
         this.supportsGain = false;
       }
-      // Force feedback requires write access and rumble support
-      this.supportsForceFeedback = !this.openedReadOnly && this.supportsRumble;
+      // Force feedback requires write access and rumble (or sine fallback) support
+      this.supportsForceFeedback = !this.openedReadOnly && (this.supportsRumble || this.supportsSine);
     }
   }
 
@@ -129,6 +139,7 @@ class LinuxEventDevice {
       this.version = 0;
       this.supportsForceFeedback = false;
       this.supportsRumble = false;
+      this.supportsSine = false;
       this.supportsGain = false;
       this.maxEffects = 0;
     } else {
@@ -139,13 +150,15 @@ class LinuxEventDevice {
       byte[] ffBits = Linux.getBits(memoryArena, EV_FF, this.fd);
       if (ffBits != null) {
         this.supportsRumble = isBitSet(ffBits, Linux.FF_RUMBLE);
+        this.supportsSine = isBitSet(ffBits, Linux.FF_SINE);
         this.supportsGain = isBitSet(ffBits, Linux.FF_GAIN);
       } else {
         this.supportsRumble = false;
+        this.supportsSine = false;
         this.supportsGain = false;
       }
-      // Force feedback requires write access and rumble support
-      this.supportsForceFeedback = !isReadOnly && this.supportsRumble;
+      // Force feedback requires write access and rumble (or sine fallback) support
+      this.supportsForceFeedback = !isReadOnly && (this.supportsRumble || this.supportsSine);
     }
   }
 
@@ -159,7 +172,7 @@ class LinuxEventDevice {
       case EV_KEY -> KEY_MAX;
       case EV_REL -> REL_MAX;
       case EV_ABS -> ABS_MAX;
-      case EV_FF -> FF_MAX;
+      case EV_FF -> Linux.FF_CNT;
       default -> 0;
     };
   }

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevice.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevice.java
@@ -35,8 +35,29 @@ class LinuxEventDevice {
   final String name;
   final input_id id;
   final List<LinuxEventComponent> componentList = new ArrayList<>();
+
+  /**
+   * Whether the device supports force feedback (rumble).
+   * Requires both write access to the device node and FF_RUMBLE capability
+   * reported via EVIOCGBIT(EV_FF). The kernel auto-sets FF_RUMBLE when
+   * FF_PERIODIC is available, so this covers both native and emulated rumble.
+   */
   final boolean supportsForceFeedback;
+
+  /**
+   * Whether the device reports FF_RUMBLE (0x50) capability via EVIOCGBIT(EV_FF).
+   * This is the authoritative way to detect rumble support — checking maxEffects
+   * alone is insufficient because a device may have effect slots but not support
+   * the rumble effect type.
+   */
   final boolean supportsRumble;
+
+  /**
+   * Whether the device reports FF_GAIN (0x60) capability via EVIOCGBIT(EV_FF).
+   * The kernel silently ignores FF_GAIN writes when unsupported (returns bytes
+   * written without applying gain), so this flag prevents false-positive gain
+   * detection that leaves rumble at zero intensity on some controllers.
+   */
   final boolean supportsGain;
   final int maxEffects;
   boolean openedReadOnly = false;

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevice.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevice.java
@@ -37,9 +37,10 @@ class LinuxEventDevice {
 
   /**
    * Whether the device supports force feedback (rumble).
-   * Requires both write access to the device node and FF_RUMBLE capability
-   * reported via EVIOCGBIT(EV_FF). The kernel auto-sets FF_RUMBLE when
-   * FF_PERIODIC is available, so this covers both native and emulated rumble.
+   * Requires write access to the device node and either FF_RUMBLE or FF_SINE
+   * capability reported via EVIOCGBIT(EV_FF). The kernel auto-sets FF_RUMBLE
+   * when FF_PERIODIC is available; FF_SINE serves as a fallback for older
+   * drivers that do not trigger the kernel's auto-emulation.
    */
   final boolean supportsForceFeedback;
 

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevice.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevice.java
@@ -36,6 +36,8 @@ class LinuxEventDevice {
   final input_id id;
   final List<LinuxEventComponent> componentList = new ArrayList<>();
   final boolean supportsForceFeedback;
+  final boolean supportsRumble;
+  final boolean supportsGain;
   final int maxEffects;
   boolean openedReadOnly = false;
 
@@ -44,7 +46,6 @@ class LinuxEventDevice {
   int currentEffectId = -1;
   float currentStrongMagnitude = 0f;
   float currentWeakMagnitude = 0f;
-  boolean gainSet = false;
 
   public int version;
 
@@ -58,14 +59,24 @@ class LinuxEventDevice {
       this.id = null;
       this.version = 0;
       this.supportsForceFeedback = false;
+      this.supportsRumble = false;
+      this.supportsGain = false;
       this.maxEffects = 0;
     } else {
       this.name = Linux.getEventDeviceName(memoryArena, this.fd);
       this.id = Linux.getEventDeviceId(memoryArena, this.fd);
       this.version = Linux.getEventDeviceVersion(memoryArena, this.fd);
       this.maxEffects = Linux.getNumEffects(memoryArena, this.fd);
-      // Force feedback requires write access - read-only disables it
-      this.supportsForceFeedback = !this.openedReadOnly && this.maxEffects > 0;
+      byte[] ffBits = Linux.getBits(memoryArena, EV_FF, this.fd);
+      if (ffBits != null) {
+        this.supportsRumble = isBitSet(ffBits, Linux.FF_RUMBLE);
+        this.supportsGain = isBitSet(ffBits, Linux.FF_GAIN);
+      } else {
+        this.supportsRumble = false;
+        this.supportsGain = false;
+      }
+      // Force feedback requires write access and rumble support
+      this.supportsForceFeedback = !this.openedReadOnly && this.supportsRumble;
     }
   }
 
@@ -96,14 +107,24 @@ class LinuxEventDevice {
       this.id = null;
       this.version = 0;
       this.supportsForceFeedback = false;
+      this.supportsRumble = false;
+      this.supportsGain = false;
       this.maxEffects = 0;
     } else {
       this.name = Linux.getEventDeviceName(memoryArena, this.fd);
       this.id = Linux.getEventDeviceId(memoryArena, this.fd);
       this.version = Linux.getEventDeviceVersion(memoryArena, this.fd);
       this.maxEffects = Linux.getNumEffects(memoryArena, this.fd);
-      // Force feedback requires write access - read-only disables it
-      this.supportsForceFeedback = !isReadOnly && this.maxEffects > 0;
+      byte[] ffBits = Linux.getBits(memoryArena, EV_FF, this.fd);
+      if (ffBits != null) {
+        this.supportsRumble = isBitSet(ffBits, Linux.FF_RUMBLE);
+        this.supportsGain = isBitSet(ffBits, Linux.FF_GAIN);
+      } else {
+        this.supportsRumble = false;
+        this.supportsGain = false;
+      }
+      // Force feedback requires write access and rumble support
+      this.supportsForceFeedback = !isReadOnly && this.supportsRumble;
     }
   }
 

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevicePlugin.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevicePlugin.java
@@ -159,6 +159,9 @@ public class LinuxEventDevicePlugin extends AbstractInputDevicePlugin {
 
       if (device.supportsForceFeedback) {
         log.log(Level.FINE, "Device supports force feedback: " + device.name + " with " + device.maxEffects + " effects");
+        if (device.supportsGain) {
+          Linux.setGain(this.memoryArena, device.fd, MAX_MAGNITUDE);
+        }
       }
 
       int vendorId = device.id != null ? Short.toUnsignedInt(device.id.vendor) : -1;
@@ -280,6 +283,7 @@ public class LinuxEventDevicePlugin extends AbstractInputDevicePlugin {
   private static final int MAX_MAGNITUDE = 65535;
 
   private final ff_effect rumbleEffectTemplate = createRumbleEffectTemplate();
+  private final ff_effect sineEffectTemplate = createSineEffectTemplate();
   private final input_event playEventTemplate = new input_event();
   private final input_event stopEventTemplate = new input_event();
 
@@ -295,6 +299,30 @@ public class LinuxEventDevicePlugin extends AbstractInputDevicePlugin {
     effect.replay.length = 0;
     effect.replay.delay = 0;
     effect.rumble = new ff_rumble_effect();
+    return effect;
+  }
+
+  private ff_effect createSineEffectTemplate() {
+    var effect = new ff_effect();
+    effect.type = Linux.FF_PERIODIC;
+    effect.id = -1;
+    effect.direction = 0;
+    effect.trigger = new ff_trigger();
+    effect.trigger.button = 0;
+    effect.trigger.interval = 0;
+    effect.replay = new ff_replay();
+    effect.replay.length = 0;
+    effect.replay.delay = 0;
+    effect.periodic = new ff_periodic_effect();
+    effect.periodic.waveform = Linux.FF_SINE;
+    effect.periodic.period = 50;
+    effect.periodic.offset = 0;
+    effect.periodic.phase = 0;
+    effect.periodic.envelope = new ff_envelope();
+    effect.periodic.envelope.attack_length = 0;
+    effect.periodic.envelope.attack_level = 0;
+    effect.periodic.envelope.fade_length = 0;
+    effect.periodic.envelope.fade_level = 0;
     return effect;
   }
 
@@ -314,15 +342,16 @@ public class LinuxEventDevicePlugin extends AbstractInputDevicePlugin {
     }
 
     if (!linuxEventDevice.supportsForceFeedback) {
+      if (linuxEventDevice.openedReadOnly) {
+        log.log(Level.WARNING, "Rumble not supported - device opened read-only (requires write access): {0}", linuxEventDevice.filename);
+      } else if (!linuxEventDevice.supportsRumble && !linuxEventDevice.supportsSine) {
+        log.log(Level.WARNING, "Rumble not supported - device does not report FF_RUMBLE or FF_SINE capability: {0}", linuxEventDevice.name);
+      }
       return;
     }
 
     if (linuxEventDevice.fd == Linux.ERROR) {
       return;
-    }
-
-    if (linuxEventDevice.supportsGain) {
-      Linux.setGain(this.memoryArena, linuxEventDevice.fd, MAX_MAGNITUDE);
     }
 
     if (intensity == null || intensity.length == 0 || (intensity.length > 0 && intensity[0] < RUMBLE_THRESHOLD && (intensity.length == 1 || intensity[1] < RUMBLE_THRESHOLD))) {
@@ -348,28 +377,54 @@ public class LinuxEventDevicePlugin extends AbstractInputDevicePlugin {
       }
     }
 
-    rumbleEffectTemplate.rumble.strong_magnitude = (short) (strongMagnitude * MAX_MAGNITUDE);
-    rumbleEffectTemplate.rumble.weak_magnitude = (short) (weakMagnitude * MAX_MAGNITUDE);
+    if (linuxEventDevice.supportsRumble) {
+      rumbleEffectTemplate.rumble.strong_magnitude = (short) (strongMagnitude * MAX_MAGNITUDE);
+      rumbleEffectTemplate.rumble.weak_magnitude = (short) (weakMagnitude * MAX_MAGNITUDE);
 
-    int effectId = Linux.uploadEffect(this.memoryArena, linuxEventDevice.fd, rumbleEffectTemplate);
-    if (effectId == Linux.ERROR) {
-      log.log(Level.WARNING, "Failed to upload rumble effect for device " + inputDevice.getName());
-      return;
-    }
+      int effectId = Linux.uploadEffect(this.memoryArena, linuxEventDevice.fd, rumbleEffectTemplate);
+      if (effectId == Linux.ERROR) {
+        log.log(Level.WARNING, "Failed to upload rumble effect for device " + inputDevice.getName());
+        return;
+      }
 
-    linuxEventDevice.currentEffectId = effectId;
-    linuxEventDevice.currentStrongMagnitude = strongMagnitude;
-    linuxEventDevice.currentWeakMagnitude = weakMagnitude;
+      linuxEventDevice.currentEffectId = effectId;
+      linuxEventDevice.currentStrongMagnitude = strongMagnitude;
+      linuxEventDevice.currentWeakMagnitude = weakMagnitude;
 
-    playEventTemplate.type = (short) LinuxEventDevice.EV_FF;
-    playEventTemplate.code = (short) effectId;
-    playEventTemplate.value = 1;
+      playEventTemplate.type = (short) LinuxEventDevice.EV_FF;
+      playEventTemplate.code = (short) effectId;
+      playEventTemplate.value = 1;
 
-    int result = Linux.writeEvent(this.memoryArena, linuxEventDevice.fd, playEventTemplate);
-    if (result == Linux.ERROR) {
-      log.log(Level.WARNING, "Failed to play rumble effect for device " + inputDevice.getName());
-      Linux.removeEffect(this.memoryArena, linuxEventDevice.fd, effectId);
-      linuxEventDevice.currentEffectId = -1;
+      int result = Linux.writeEvent(this.memoryArena, linuxEventDevice.fd, playEventTemplate);
+      if (result == Linux.ERROR) {
+        log.log(Level.WARNING, "Failed to play rumble effect for device " + inputDevice.getName());
+        Linux.removeEffect(this.memoryArena, linuxEventDevice.fd, effectId);
+        linuxEventDevice.currentEffectId = -1;
+      }
+    } else {
+      int magnitude = (int) (strongMagnitude * MAX_MAGNITUDE / 3 + weakMagnitude * MAX_MAGNITUDE / 6);
+      sineEffectTemplate.periodic.magnitude = (short) magnitude;
+
+      int effectId = Linux.uploadEffect(this.memoryArena, linuxEventDevice.fd, sineEffectTemplate);
+      if (effectId == Linux.ERROR) {
+        log.log(Level.WARNING, "Failed to upload sine fallback effect for device " + inputDevice.getName());
+        return;
+      }
+
+      linuxEventDevice.currentEffectId = effectId;
+      linuxEventDevice.currentStrongMagnitude = strongMagnitude;
+      linuxEventDevice.currentWeakMagnitude = weakMagnitude;
+
+      playEventTemplate.type = (short) LinuxEventDevice.EV_FF;
+      playEventTemplate.code = (short) effectId;
+      playEventTemplate.value = 1;
+
+      int result = Linux.writeEvent(this.memoryArena, linuxEventDevice.fd, playEventTemplate);
+      if (result == Linux.ERROR) {
+        log.log(Level.WARNING, "Failed to play sine fallback effect for device " + inputDevice.getName());
+        Linux.removeEffect(this.memoryArena, linuxEventDevice.fd, effectId);
+        linuxEventDevice.currentEffectId = -1;
+      }
     }
   }
 

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevicePlugin.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevicePlugin.java
@@ -321,11 +321,8 @@ public class LinuxEventDevicePlugin extends AbstractInputDevicePlugin {
       return;
     }
 
-    if (!linuxEventDevice.gainSet) {
-      int gainResult = Linux.setGain(this.memoryArena, linuxEventDevice.fd, MAX_MAGNITUDE);
-      if (gainResult != Linux.ERROR) {
-        linuxEventDevice.gainSet = true;
-      }
+    if (linuxEventDevice.supportsGain) {
+      Linux.setGain(this.memoryArena, linuxEventDevice.fd, MAX_MAGNITUDE);
     }
 
     if (intensity == null || intensity.length == 0 || (intensity.length > 0 && intensity[0] < RUMBLE_THRESHOLD && (intensity.length == 1 || intensity[1] < RUMBLE_THRESHOLD))) {

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/ff_effect.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/ff_effect.java
@@ -50,8 +50,15 @@ class ff_effect {
   /**
    * Effect-specific data (union of different effect types).
    * For rumble effects, use the rumble field.
+   * For periodic effects (sine, square, etc.), use the periodic field.
    */
   public ff_rumble_effect rumble;
+
+  /**
+   * Periodic effect data (FF_PERIODIC type).
+   * Shares the same memory as rumble (union in C kernel struct).
+   */
+  public ff_periodic_effect periodic;
 
   static final int FF_EFFECT_MAX = 24;
 
@@ -80,6 +87,7 @@ class ff_effect {
     effect.trigger = ff_trigger.read(segment.asSlice(OFFSET_trigger));
     effect.replay = ff_replay.read(segment.asSlice(OFFSET_replay));
     effect.rumble = ff_rumble_effect.read(segment.asSlice(OFFSET_u));
+    effect.periodic = ff_periodic_effect.read(segment.asSlice(OFFSET_u));
     return effect;
   }
 
@@ -96,6 +104,9 @@ class ff_effect {
     }
     if (rumble != null) {
       rumble.write(segment.asSlice(OFFSET_u));
+    }
+    if (periodic != null) {
+      periodic.write(segment.asSlice(OFFSET_u));
     }
   }
 }

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/ff_envelope.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/ff_envelope.java
@@ -1,0 +1,51 @@
+package de.gurkenlabs.input4j.foreign.linux;
+
+import java.lang.foreign.GroupLayout;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.invoke.VarHandle;
+
+import static java.lang.foreign.ValueLayout.JAVA_SHORT;
+
+/**
+ * struct ff_envelope - generic force-feedback effect envelope.
+ *
+ * <p>
+ * Defines the attack and fade characteristics of a force-feedback effect.
+ * Attack is the ramp-up at the beginning, fade is the ramp-down at the end.
+ * </p>
+ */
+class ff_envelope {
+  public short attack_length;
+  public short attack_level;
+  public short fade_length;
+  public short fade_level;
+
+  static final GroupLayout $LAYOUT = MemoryLayout.structLayout(
+      JAVA_SHORT.withName("attack_length"),
+      JAVA_SHORT.withName("attack_level"),
+      JAVA_SHORT.withName("fade_length"),
+      JAVA_SHORT.withName("fade_level")
+  ).withName("ff_envelope");
+
+  static final VarHandle VH_attack_length = $LAYOUT.varHandle(MemoryLayout.PathElement.groupElement("attack_length"));
+  static final VarHandle VH_attack_level = $LAYOUT.varHandle(MemoryLayout.PathElement.groupElement("attack_level"));
+  static final VarHandle VH_fade_length = $LAYOUT.varHandle(MemoryLayout.PathElement.groupElement("fade_length"));
+  static final VarHandle VH_fade_level = $LAYOUT.varHandle(MemoryLayout.PathElement.groupElement("fade_level"));
+
+  public static ff_envelope read(MemorySegment segment) {
+    var envelope = new ff_envelope();
+    envelope.attack_length = (short) VH_attack_length.get(segment, 0);
+    envelope.attack_level = (short) VH_attack_level.get(segment, 0);
+    envelope.fade_length = (short) VH_fade_length.get(segment, 0);
+    envelope.fade_level = (short) VH_fade_level.get(segment, 0);
+    return envelope;
+  }
+
+  public void write(MemorySegment segment) {
+    VH_attack_length.set(segment, 0, attack_length);
+    VH_attack_level.set(segment, 0, attack_level);
+    VH_fade_length.set(segment, 0, fade_length);
+    VH_fade_level.set(segment, 0, fade_level);
+  }
+}

--- a/src/main/java/de/gurkenlabs/input4j/foreign/linux/ff_periodic_effect.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/linux/ff_periodic_effect.java
@@ -1,0 +1,64 @@
+package de.gurkenlabs.input4j.foreign.linux;
+
+import java.lang.foreign.GroupLayout;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.invoke.VarHandle;
+
+import static java.lang.foreign.ValueLayout.JAVA_SHORT;
+
+/**
+ * struct ff_periodic_effect - parameters for a periodic force-feedback effect.
+ *
+ * <p>
+ * Defines a periodic waveform effect (sine, square, triangle, sawtooth).
+ * Used as a fallback for rumble on devices that support FF_PERIODIC but not FF_RUMBLE.
+ * </p>
+ */
+class ff_periodic_effect {
+  public short waveform;
+  public short period;
+  public short magnitude;
+  public short offset;
+  public short phase;
+  public ff_envelope envelope;
+
+  static final GroupLayout $LAYOUT = MemoryLayout.structLayout(
+      JAVA_SHORT.withName("waveform"),
+      JAVA_SHORT.withName("period"),
+      JAVA_SHORT.withName("magnitude"),
+      JAVA_SHORT.withName("offset"),
+      JAVA_SHORT.withName("phase"),
+      ff_envelope.$LAYOUT.withName("envelope")
+  ).withName("ff_periodic_effect");
+
+  static final VarHandle VH_waveform = $LAYOUT.varHandle(MemoryLayout.PathElement.groupElement("waveform"));
+  static final VarHandle VH_period = $LAYOUT.varHandle(MemoryLayout.PathElement.groupElement("period"));
+  static final VarHandle VH_magnitude = $LAYOUT.varHandle(MemoryLayout.PathElement.groupElement("magnitude"));
+  static final VarHandle VH_offset = $LAYOUT.varHandle(MemoryLayout.PathElement.groupElement("offset"));
+  static final VarHandle VH_phase = $LAYOUT.varHandle(MemoryLayout.PathElement.groupElement("phase"));
+
+  static final long OFFSET_envelope = $LAYOUT.byteOffset(MemoryLayout.PathElement.groupElement("envelope"));
+
+  public static ff_periodic_effect read(MemorySegment segment) {
+    var effect = new ff_periodic_effect();
+    effect.waveform = (short) VH_waveform.get(segment, 0);
+    effect.period = (short) VH_period.get(segment, 0);
+    effect.magnitude = (short) VH_magnitude.get(segment, 0);
+    effect.offset = (short) VH_offset.get(segment, 0);
+    effect.phase = (short) VH_phase.get(segment, 0);
+    effect.envelope = ff_envelope.read(segment.asSlice(OFFSET_envelope));
+    return effect;
+  }
+
+  public void write(MemorySegment segment) {
+    VH_waveform.set(segment, 0, waveform);
+    VH_period.set(segment, 0, period);
+    VH_magnitude.set(segment, 0, magnitude);
+    VH_offset.set(segment, 0, offset);
+    VH_phase.set(segment, 0, phase);
+    if (envelope != null) {
+      envelope.write(segment.asSlice(OFFSET_envelope));
+    }
+  }
+}

--- a/src/test/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevicePluginTests.java
+++ b/src/test/java/de/gurkenlabs/input4j/foreign/linux/LinuxEventDevicePluginTests.java
@@ -8,6 +8,8 @@ import de.gurkenlabs.input4j.components.Button;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LinuxEventDevicePluginTests {
   @Test
@@ -124,5 +126,47 @@ public class LinuxEventDevicePluginTests {
     event.code = 4;
     index = LinuxEventDevicePlugin.getComponentIndexByNativeId(event, inputDevice);
     assertEquals(Linux.ERROR, index);
+  }
+
+  @Test
+  void testIsBitSetForFfRumble() {
+    byte[] ffBits = new byte[16];
+    ffBits[10] = (byte) 0x01;
+    assertTrue(LinuxEventDevice.isBitSet(ffBits, Linux.FF_RUMBLE));
+    assertFalse(LinuxEventDevice.isBitSet(ffBits, Linux.FF_SINE));
+    assertFalse(LinuxEventDevice.isBitSet(ffBits, Linux.FF_GAIN));
+  }
+
+  @Test
+  void testIsBitSetForFfSine() {
+    byte[] ffBits = new byte[16];
+    ffBits[11] = (byte) 0x04;
+    assertTrue(LinuxEventDevice.isBitSet(ffBits, Linux.FF_SINE));
+    assertFalse(LinuxEventDevice.isBitSet(ffBits, Linux.FF_RUMBLE));
+    assertFalse(LinuxEventDevice.isBitSet(ffBits, Linux.FF_GAIN));
+  }
+
+  @Test
+  void testIsBitSetForFfGain() {
+    byte[] ffBits = new byte[16];
+    ffBits[12] = (byte) 0x01;
+    assertTrue(LinuxEventDevice.isBitSet(ffBits, Linux.FF_GAIN));
+    assertFalse(LinuxEventDevice.isBitSet(ffBits, Linux.FF_RUMBLE));
+    assertFalse(LinuxEventDevice.isBitSet(ffBits, Linux.FF_SINE));
+  }
+
+  @Test
+  void testIsBitSetForFfRumbleAndGain() {
+    byte[] ffBits = new byte[16];
+    ffBits[10] = (byte) 0x01;
+    ffBits[12] = (byte) 0x01;
+    assertTrue(LinuxEventDevice.isBitSet(ffBits, Linux.FF_RUMBLE));
+    assertFalse(LinuxEventDevice.isBitSet(ffBits, Linux.FF_SINE));
+    assertTrue(LinuxEventDevice.isBitSet(ffBits, Linux.FF_GAIN));
+  }
+
+  @Test
+  void testGetMaxBitsForEvFfReturnsFfCnt() {
+    assertEquals(Linux.FF_CNT, LinuxEventDevice.getMaxBits(LinuxEventDevice.EV_FF));
   }
 }

--- a/src/test/java/de/gurkenlabs/input4j/foreign/linux/LinuxForceFeedbackStructTests.java
+++ b/src/test/java/de/gurkenlabs/input4j/foreign/linux/LinuxForceFeedbackStructTests.java
@@ -114,4 +114,130 @@ public class LinuxForceFeedbackStructTests {
     int magnitude = (int) (intensity4 * 65535);
     assertTrue(magnitude > 40000 && magnitude < 50000);
   }
+
+  @Test
+  public void testFfEnvelope() {
+    try (var memorySession = Arena.ofConfined()) {
+      var envelope = new ff_envelope();
+      envelope.attack_length = 100;
+      envelope.attack_level = 32767;
+      envelope.fade_length = 200;
+      envelope.fade_level = 16384;
+
+      var segment = memorySession.allocate(ff_envelope.$LAYOUT);
+      envelope.write(segment);
+
+      var envelopeFromMemory = ff_envelope.read(segment);
+      assertEquals(envelope.attack_length, envelopeFromMemory.attack_length);
+      assertEquals(envelope.attack_level, envelopeFromMemory.attack_level);
+      assertEquals(envelope.fade_length, envelopeFromMemory.fade_length);
+      assertEquals(envelope.fade_level, envelopeFromMemory.fade_level);
+    }
+  }
+
+  @Test
+  public void testFfPeriodicEffect() {
+    try (var memorySession = Arena.ofConfined()) {
+      var periodic = new ff_periodic_effect();
+      periodic.waveform = Linux.FF_SINE;
+      periodic.period = 50;
+      periodic.magnitude = 30000;
+      periodic.offset = 0;
+      periodic.phase = 0;
+      periodic.envelope = new ff_envelope();
+      periodic.envelope.attack_length = 0;
+      periodic.envelope.attack_level = 0;
+      periodic.envelope.fade_length = 0;
+      periodic.envelope.fade_level = 0;
+
+      var segment = memorySession.allocate(ff_periodic_effect.$LAYOUT);
+      periodic.write(segment);
+
+      var periodicFromMemory = ff_periodic_effect.read(segment);
+      assertEquals(periodic.waveform, periodicFromMemory.waveform);
+      assertEquals(periodic.period, periodicFromMemory.period);
+      assertEquals(periodic.magnitude, periodicFromMemory.magnitude);
+      assertEquals(periodic.offset, periodicFromMemory.offset);
+      assertEquals(periodic.phase, periodicFromMemory.phase);
+      assertEquals(periodic.envelope.attack_length, periodicFromMemory.envelope.attack_length);
+      assertEquals(periodic.envelope.attack_level, periodicFromMemory.envelope.attack_level);
+      assertEquals(periodic.envelope.fade_length, periodicFromMemory.envelope.fade_length);
+      assertEquals(periodic.envelope.fade_level, periodicFromMemory.envelope.fade_level);
+    }
+  }
+
+  @Test
+  public void testFfEffectWithPeriodic() {
+    try (var memorySession = Arena.ofConfined()) {
+      var effect = new ff_effect();
+      effect.type = Linux.FF_PERIODIC;
+      effect.id = -1;
+      effect.direction = 0;
+
+      effect.trigger = new ff_trigger();
+      effect.trigger.button = 0;
+      effect.trigger.interval = 0;
+
+      effect.replay = new ff_replay();
+      effect.replay.length = 0;
+      effect.replay.delay = 0;
+
+      effect.periodic = new ff_periodic_effect();
+      effect.periodic.waveform = Linux.FF_SINE;
+      effect.periodic.period = 50;
+      effect.periodic.magnitude = 20000;
+      effect.periodic.offset = 0;
+      effect.periodic.phase = 0;
+      effect.periodic.envelope = new ff_envelope();
+      effect.periodic.envelope.attack_length = 0;
+      effect.periodic.envelope.attack_level = 0;
+      effect.periodic.envelope.fade_length = 0;
+      effect.periodic.envelope.fade_level = 0;
+
+      var segment = memorySession.allocate(ff_effect.$LAYOUT);
+      effect.write(segment);
+
+      var effectFromMemory = ff_effect.read(segment);
+      assertEquals(effect.type, effectFromMemory.type);
+      assertEquals(effect.id, effectFromMemory.id);
+      assertEquals(effect.periodic.waveform, effectFromMemory.periodic.waveform);
+      assertEquals(effect.periodic.period, effectFromMemory.periodic.period);
+      assertEquals(effect.periodic.magnitude, effectFromMemory.periodic.magnitude);
+    }
+  }
+
+  @Test
+  public void testFfConstants() {
+    assertEquals(0x50, Linux.FF_RUMBLE);
+    assertEquals(0x51, Linux.FF_PERIODIC);
+    assertEquals(0x57, Linux.FF_EFFECT_MAX);
+    assertEquals(0x57, Linux.FF_RAMP);
+    assertEquals(0x5a, Linux.FF_SINE);
+    assertEquals(0x60, Linux.FF_GAIN);
+    assertEquals(0x7f, Linux.FF_MAX);
+    assertEquals(0x80, Linux.FF_CNT);
+  }
+
+  @Test
+  public void testSineFallbackMagnitudeMatchesKernelCompatEffect() {
+    float strong = 1.0f;
+    float weak = 1.0f;
+    int magnitude = (int) (strong * 65535 / 3 + weak * 65535 / 6);
+    assertEquals(32767, magnitude);
+
+    strong = 1.0f;
+    weak = 0.0f;
+    magnitude = (int) (strong * 65535 / 3 + weak * 65535 / 6);
+    assertEquals(21845, magnitude);
+
+    strong = 0.0f;
+    weak = 1.0f;
+    magnitude = (int) (strong * 65535 / 3 + weak * 65535 / 6);
+    assertEquals(10922, magnitude);
+
+    strong = 0.5f;
+    weak = 0.5f;
+    magnitude = (int) (strong * 65535 / 3 + weak * 65535 / 6);
+    assertEquals(16383, magnitude);
+  }
 }


### PR DESCRIPTION
### Problem
Gamepad rumble/vibration does not work on Linux despite no errors being thrown. The root cause was that the plugin determined force feedback support solely by checking `maxEffects > 0`, which only indicates available effect slots — not whether the device actually supports the `FF_RUMBLE` effect type. Additionally, the kernel silently ignores `FF_GAIN` writes when unsupported, causing a false-positive "gain set" flag that left rumble at zero intensity on some controllers.
### Changes
**1. Query `EV_FF` feature bits for actual capability detection**
- Added `supportsRumble`, `supportsSine`, and `supportsGain` fields to `LinuxEventDevice`
- Both constructors now call `EVIOCGBIT(EV_FF, ...)` to detect actual FF capabilities
- `supportsForceFeedback` is now based on `supportsRumble || supportsSine` instead of `maxEffects > 0`

**2. Fix gain handling**
- Removed broken `gainSet`-once pattern (kernel silently ignores unsupported FF_GAIN writes, causing false success)
- Gain is now set once during device initialization (persistent per-fd in kernel), not on every rumble call
- Only attempts gain when device reports `FF_GAIN` capability

**3. Add FF_SINE fallback for rumble**
- When `FF_RUMBLE` is unavailable but `FF_SINE` is supported, uses a periodic sine wave effect
- Magnitude formula matches kernel's `compat_effect()`: `strong/3 + weak/6`
- Covers older drivers that don't trigger the kernel's FF_RUMBLE auto-emulation

**4. Add warning logging for silent failures**
- Logs specific reason when rumble is unavailable (read-only access vs. missing capability)
- Users can now diagnose issues instead of getting silent "no error, no vibration" behavior

**5. Fix FF constant inconsistency**
- `FF_EFFECT_MAX`: `0x5f` → `0x57` (FF_RAMP), matching kernel definition
- `getMaxBits(EV_FF)` now returns `FF_CNT` (128) for full feature bit coverage
- Added `FF_SINE` constant (`0x5a`)
### Files Changed
| File | Change |
|------|--------|
| `Linux.java` | Fix `FF_EFFECT_MAX`, add `FF_SINE` constant |
| `LinuxEventDevice.java` | Add `supportsRumble`, `supportsSine`, `supportsGain` fields; query EV_FF bits in both constructors |
| `LinuxEventDevicePlugin.java` | Move gain to init, add warning logging, add FF_SINE fallback path |
| `ff_effect.java` | Add `periodic` field for union access |
| `ff_envelope.java` | New — `struct ff_envelope` |
| `ff_periodic_effect.java` | New — `struct ff_periodic_effect` |
### How It Works
1. Open device with `O_RDWR` for write access (required for FF)
2. Query `EVIOCGBIT(EV_FF, ...)` to get supported FF features
3. Check `FF_RUMBLE` bit (or `FF_SINE` as fallback)
4. Set gain to maximum if `FF_GAIN` is supported
5. Upload and play rumble effect via `EVIOCSFF` + `write()`

### Related 
Fixes #50 