### PR TITLE
Fix/57 macos iosetelement not found

### DIFF
--- a/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOHIDElement.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOHIDElement.java
@@ -92,7 +92,7 @@ class IOHIDElement {
    */
   int reportSize;
 
-  int currentValue;
+  volatile int currentValue;
 
   String getName() {
     if (this.name != null) {

--- a/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOHIDElement.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOHIDElement.java
@@ -17,6 +17,16 @@ class IOHIDElement {
   long address;
 
   /**
+   * The 32-bit identifier unique to this element within its parent device,
+   * as reported by {@code IOHIDElementGetCookie}. Apple guarantees that
+   * this value is stable for the lifetime of the device and is unique
+   * among siblings. We use it as the disambiguation key in the input
+   * value callback so the lookup is robust against FFM address-carrier
+   * quirks that can confuse raw pointer comparison.
+   */
+  int cookie;
+
+  /**
    * The name of the HID element.
    * Corresponds to the `kIOHIDElementNameKey` in native C.
    */

--- a/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPlugin.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPlugin.java
@@ -193,7 +193,7 @@ public class IOKitPlugin extends AbstractInputDevicePlugin {
     // find element from the list in this instance according to the address of the element
     var ioHIDElement = this.nativeDevices.values().stream().flatMap(x -> x.getElements().stream()).filter(x -> x.address == element.address()).findFirst().orElse(null);
     if (ioHIDElement == null) {
-      log.log(Level.WARNING, "IOHIDElement not found for address " + element.address());
+      log.log(Level.FINE, "IOHIDElement not found for address " + element.address());
       return;
     }
 

--- a/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPlugin.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPlugin.java
@@ -55,7 +55,20 @@ public class IOKitPlugin extends AbstractInputDevicePlugin {
    */
   private final Map<Long, Map<Integer, IOHIDElement>> elementsByDeviceAndCookie = new ConcurrentHashMap<>();
   private Thread eventLoopThread;
+  /**
+   * {@code CFRunLoopRef} of the event-loop thread, captured before
+   * {@link #internalInitDevices(Frame)} releases the calling thread via
+   * {@code initLatch.countDown()}. Used by {@link #close()} to wake the
+   * blocked {@code CFRunLoopRun} so the thread can exit cleanly.
+   * {@code volatile} because it is written by the event-loop thread and
+   * read by any thread that calls {@code close()}; the write happens
+   * before the latch count-down, which establishes happens-before with
+   * any thread that has already observed the latch release.
+   */
+  private volatile MemorySegment eventLoopRunLoop;
   private Arena batteryArena;
+
+  private static final long SHUTDOWN_TIMEOUT_MS = 3_000;
 
   @Override
   public void internalInitDevices(Frame owner) {
@@ -69,6 +82,7 @@ public class IOKitPlugin extends AbstractInputDevicePlugin {
         var ioHIDDevices = MacOS.getSupportedHIDDevices(memoryArena, ioHIDManager);
 
         populateDevices(ioHIDDevices);
+        this.eventLoopRunLoop = MacOS.CFRunLoopGetCurrent();
         initLatch.countDown();
 
         if (!nativeDevices.isEmpty()) {
@@ -163,14 +177,27 @@ public class IOKitPlugin extends AbstractInputDevicePlugin {
 
   @Override
   public void close() {
-    super.close();
+    if (eventLoopRunLoop != null && !eventLoopRunLoop.equals(MemorySegment.NULL)) {
+      try {
+        MacOS.CFRunLoopStop(eventLoopRunLoop);
+      } catch (Throwable t) {
+        log.log(Level.WARNING, "Failed to stop HID event loop", t);
+      }
+    }
 
     if (eventLoopThread != null) {
-      eventLoopThread.interrupt();
+      try {
+        eventLoopThread.join(SHUTDOWN_TIMEOUT_MS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
     }
+
+    super.close();
 
     this.nativeDevices.clear();
     this.elementsByDeviceAndCookie.clear();
+    this.eventLoopRunLoop = null;
   }
 
   @Override

--- a/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPlugin.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPlugin.java
@@ -44,6 +44,15 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
  */
 public class IOKitPlugin extends AbstractInputDevicePlugin {
   private final Map<String, IOHIDDevice> nativeDevices = new ConcurrentHashMap<>();
+  /**
+   * Cookie-based reverse index used by {@link #hidInputValueCallback} to
+   * resolve an incoming {@code IOHIDValue} to the {@link IOHIDElement} that
+   * produced it. The outer key is the {@code IOHIDDeviceRef} address; the
+   * inner key is the element's {@code IOHIDElementGetCookie} value. The
+   * cookie is unique within a device, so this lookup is robust against any
+   * ambiguity in raw {@code IOHIDElementRef} pointer comparison.
+   */
+  private final Map<Long, Map<Integer, IOHIDElement>> elementsByDeviceAndCookie = new ConcurrentHashMap<>();
   private Thread eventLoopThread;
   private Arena batteryArena;
 
@@ -119,7 +128,9 @@ public class IOKitPlugin extends AbstractInputDevicePlugin {
       var inputDevice = new InputDevice(Long.toString(ioHIDDevice.address), ioHIDDevice.productName, ioHIDDevice.manufacturer + " (" + ioHIDDevice.transport + ")", ioHIDDevice.vendorId, ioHIDDevice.productId, displayName, this::pollIOHIDDevice, this::rumbleIOHIDDevice, this::getBatteryInfo);
       ioHIDDevice.inputDevice = inputDevice;
 
+      var cookieIndex = new ConcurrentHashMap<Integer, IOHIDElement>();
       for (var element : ioHIDDevice.getElements()) {
+        cookieIndex.put(element.cookie, element);
         if (element.getUsage() == IOHIDElementUsage.UNDEFINED) {
           continue;
         }
@@ -130,7 +141,23 @@ public class IOKitPlugin extends AbstractInputDevicePlugin {
 
       IOKitVirtualComponentHandler.prepareVirtualComponents(inputDevice, inputDevice.getComponents());
       nativeDevices.put(inputDevice.getID(), ioHIDDevice);
+      elementsByDeviceAndCookie.put(ioHIDDevice.address, cookieIndex);
     }
+  }
+
+  /**
+   * Resolves an input value to its originating {@link IOHIDElement} using
+   * the cookie-based lookup. Returns {@code null} if the device is not
+   * registered or if the cookie is unknown.
+   * <p>
+   * Package-private for unit testing.
+   */
+  IOHIDElement findElement(long deviceAddress, int cookie) {
+    var deviceMap = elementsByDeviceAndCookie.get(deviceAddress);
+    if (deviceMap == null) {
+      return null;
+    }
+    return deviceMap.get(cookie);
   }
 
   @Override
@@ -142,6 +169,7 @@ public class IOKitPlugin extends AbstractInputDevicePlugin {
     }
 
     this.nativeDevices.clear();
+    this.elementsByDeviceAndCookie.clear();
   }
 
   @Override
@@ -203,13 +231,21 @@ public class IOKitPlugin extends AbstractInputDevicePlugin {
    * This is called out of native code when an IOHIDElement  provides a value.
    */
   private void hidInputValueCallback(MemorySegment context, int result, MemorySegment sender, MemorySegment ioHIDValueRef) {
+    // The sender parameter is the IOHIDDeviceRef that produced the value.
+    // Together with the element's cookie (a 32-bit identifier unique within
+    // a device) we can resolve the value back to the exact IOHIDElement
+    // without relying on raw IOHIDElementRef pointer comparison, which can
+    // be unreliable when the FFM downcall layer hands us a carrier
+    // MemorySegment.
+    var deviceAddress = sender.address();
     var element = MacOS.IOHIDValueGetElement(ioHIDValueRef);
-    var value = MacOS.IOHIDValueGetIntegerValue(ioHIDValueRef);
-    var timestamp = MacOS.IOHIDValueGetTimeStamp(ioHIDValueRef);
-    // find element from the list in this instance according to the address of the element
-    var ioHIDElement = this.nativeDevices.values().stream().flatMap(x -> x.getElements().stream()).filter(x -> x.address == element.address()).findFirst().orElse(null);
+    int cookie = MacOS.IOHIDElementGetCookie(element);
+    int value = MacOS.IOHIDValueGetIntegerValue(ioHIDValueRef);
+    MacOS.IOHIDValueGetTimeStamp(ioHIDValueRef);
+
+    var ioHIDElement = findElement(deviceAddress, cookie);
     if (ioHIDElement == null) {
-      log.log(Level.FINE, "IOHIDElement not found for address " + element.address());
+      log.log(Level.FINE, "IOHIDElement not found for device " + deviceAddress + " cookie " + cookie);
       return;
     }
 

--- a/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPlugin.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPlugin.java
@@ -245,7 +245,6 @@ public class IOKitPlugin extends AbstractInputDevicePlugin {
     var element = MacOS.IOHIDValueGetElement(ioHIDValueRef);
     int cookie = MacOS.IOHIDElementGetCookie(element);
     int value = MacOS.IOHIDValueGetIntegerValue(ioHIDValueRef);
-    MacOS.IOHIDValueGetTimeStamp(ioHIDValueRef);
 
     var ioHIDElement = findElement(deviceAddress, cookie);
     if (ioHIDElement == null) {

--- a/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPlugin.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPlugin.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
+
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
@@ -56,12 +57,10 @@ public class IOKitPlugin extends AbstractInputDevicePlugin {
   private Thread eventLoopThread;
   private Arena batteryArena;
 
-  private CountDownLatch initLatch;
-
   @Override
   public void internalInitDevices(Frame owner) {
     batteryArena = Arena.ofShared();
-    initLatch = new CountDownLatch(1);
+    var initLatch = new CountDownLatch(1);
     eventLoopThread = new Thread(() -> {
       MemorySegment ioHIDManager = MemorySegment.NULL;
       try (Arena memoryArena = Arena.ofConfined()) {
@@ -74,7 +73,6 @@ public class IOKitPlugin extends AbstractInputDevicePlugin {
 
         if (!nativeDevices.isEmpty()) {
           log.log(Level.FINE, "Starting event loop for HID manager");
-          // Start the event loop in a separate thread
           MacOS.runEventLoop(memoryArena, ioHIDManager);
         }
       } catch (Throwable e) {
@@ -93,7 +91,6 @@ public class IOKitPlugin extends AbstractInputDevicePlugin {
     eventLoopThread.start();
 
     try {
-      // Wait for devices to be initialized or timeout after 3 seconds to prevent blocking the main thread
       if (!initLatch.await(3, TimeUnit.SECONDS)) {
         log.log(Level.WARNING, "Device initialization timed out");
       } else {

--- a/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPlugin.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPlugin.java
@@ -70,10 +70,6 @@ public class IOKitPlugin extends AbstractInputDevicePlugin {
         var ioHIDDevices = MacOS.getSupportedHIDDevices(memoryArena, ioHIDManager);
 
         populateDevices(ioHIDDevices);
-
-        // Set the devices BEFORE the blocking run loop so the caller of init() can
-        // observe them as soon as we are done discovering.
-        this.setDevices(this.nativeDevices.values().stream().map(d -> d.inputDevice).toList());
         initLatch.countDown();
 
         if (!nativeDevices.isEmpty()) {
@@ -111,8 +107,9 @@ public class IOKitPlugin extends AbstractInputDevicePlugin {
 
   /**
    * Assembles {@link InputDevice} wrappers for the given discovered native
-   * devices, attaches their components, runs virtual-component preparation
-   * and registers the devices in {@link #nativeDevices}.
+   * devices, attaches their components, runs virtual-component preparation,
+   * registers the devices in {@link #nativeDevices} and publishes the
+   * resulting {@link InputDevice}s via {@link #setDevices}.
    * <p>
    * Package-private for unit testing so that the FFM-bound discovery path
    * can be exercised on non-macOS hosts by passing in hand-built
@@ -143,6 +140,13 @@ public class IOKitPlugin extends AbstractInputDevicePlugin {
       nativeDevices.put(inputDevice.getID(), ioHIDDevice);
       elementsByDeviceAndCookie.put(ioHIDDevice.address, cookieIndex);
     }
+
+    // Publish the input devices so callers of getAll() can observe them as
+    // soon as we are done discovering. Must be called from the event-loop
+    // thread (which is the only thread that runs populateDevices) so that
+    // the writes to AbstractInputDevicePlugin.devices / .lastDeviceUpdate
+    // happen-before the main thread wakes from initLatch.await().
+    this.setDevices(this.nativeDevices.values().stream().map(d -> d.inputDevice).toList());
   }
 
   /**

--- a/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPlugin.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPlugin.java
@@ -19,6 +19,8 @@ import java.lang.invoke.MethodType;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
@@ -45,11 +47,12 @@ public class IOKitPlugin extends AbstractInputDevicePlugin {
   private Thread eventLoopThread;
   private Arena batteryArena;
 
-  private boolean devicesInitialized;
+  private CountDownLatch initLatch;
 
   @Override
   public void internalInitDevices(Frame owner) {
     batteryArena = Arena.ofShared();
+    initLatch = new CountDownLatch(1);
     eventLoopThread = new Thread(() -> {
       MemorySegment ioHIDManager = MemorySegment.NULL;
       try (Arena memoryArena = Arena.ofConfined()) {
@@ -76,16 +79,19 @@ public class IOKitPlugin extends AbstractInputDevicePlugin {
           nativeDevices.put(inputDevice.getID(), ioHIDDevice);
         }
 
-        devicesInitialized = true;
+        // Set the devices BEFORE the blocking run loop so the caller of init() can
+        // observe them as soon as we are done discovering.
+        this.setDevices(this.nativeDevices.values().stream().map(d -> d.inputDevice).toList());
+        initLatch.countDown();
+
         if (!nativeDevices.isEmpty()) {
           log.log(Level.FINE, "Starting event loop for HID manager");
           // Start the event loop in a separate thread
           MacOS.runEventLoop(memoryArena, ioHIDManager);
         }
-
-        this.setDevices(this.nativeDevices.values().stream().map(d -> d.inputDevice).toList());
       } catch (Throwable e) {
         log.log(Level.SEVERE, "Failed to initialize IOKit devices", e);
+        initLatch.countDown();
       } finally {
         if (!ioHIDManager.equals(MemorySegment.NULL)) {
           var closeReturn = MacOS.IOHIDManagerClose(ioHIDManager);
@@ -98,22 +104,16 @@ public class IOKitPlugin extends AbstractInputDevicePlugin {
 
     eventLoopThread.start();
 
-    // Wait for devices to be initialized or timeout after 3 seconds to prevent blocking the main thread
-    int waited = 0;
-    while (waited < 3000 && !devicesInitialized) {
-      try {
-        Thread.sleep(100);
-        waited += 100;
-      } catch (InterruptedException e) {
-        log.log(Level.SEVERE, "Initialization interrupted", e);
-        throw new RuntimeException(e);
+    try {
+      // Wait for devices to be initialized or timeout after 3 seconds to prevent blocking the main thread
+      if (!initLatch.await(3, TimeUnit.SECONDS)) {
+        log.log(Level.WARNING, "Device initialization timed out");
+      } else {
+        log.log(Level.FINE, "Devices initialized successfully");
       }
-    }
-
-    if (devicesInitialized) {
-      log.log(Level.FINE, "Devices initialized successfully");
-    } else {
-      log.log(Level.WARNING, "Device initialization timed out");
+    } catch (InterruptedException e) {
+      log.log(Level.SEVERE, "Initialization interrupted", e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPlugin.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPlugin.java
@@ -60,24 +60,7 @@ public class IOKitPlugin extends AbstractInputDevicePlugin {
         ioHIDManager = MacOS.initHIDManager(hidInputValueCallbackPointer(memoryArena));
         var ioHIDDevices = MacOS.getSupportedHIDDevices(memoryArena, ioHIDManager);
 
-        for (var ioHIDDevice : ioHIDDevices) {
-          log.log(Level.FINE, "Found HID device: " + ioHIDDevice.productName);
-          String displayName = ControllerDatabase.getDisplayName(ioHIDDevice.vendorId, ioHIDDevice.productId);
-          var inputDevice = new InputDevice(Long.toString(ioHIDDevice.address), ioHIDDevice.productName, ioHIDDevice.manufacturer + " (" + ioHIDDevice.transport + ")", ioHIDDevice.vendorId, ioHIDDevice.productId, displayName, this::pollIOHIDDevice, this::rumbleIOHIDDevice, this::getBatteryInfo);
-          ioHIDDevice.inputDevice = inputDevice;
-
-          for (var element : ioHIDDevice.getElements()) {
-            if (element.getUsage() == IOHIDElementUsage.UNDEFINED) {
-              continue;
-            }
-
-            var component = new InputComponent(inputDevice, element.getIdentifier(), element.getName());
-            inputDevice.addComponent(component);
-          }
-
-          IOKitVirtualComponentHandler.prepareVirtualComponents(inputDevice, inputDevice.getComponents());
-          nativeDevices.put(inputDevice.getID(), ioHIDDevice);
-        }
+        populateDevices(ioHIDDevices);
 
         // Set the devices BEFORE the blocking run loop so the caller of init() can
         // observe them as soon as we are done discovering.
@@ -114,6 +97,39 @@ public class IOKitPlugin extends AbstractInputDevicePlugin {
     } catch (InterruptedException e) {
       log.log(Level.SEVERE, "Initialization interrupted", e);
       throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Assembles {@link InputDevice} wrappers for the given discovered native
+   * devices, attaches their components, runs virtual-component preparation
+   * and registers the devices in {@link #nativeDevices}.
+   * <p>
+   * Package-private for unit testing so that the FFM-bound discovery path
+   * can be exercised on non-macOS hosts by passing in hand-built
+   * {@link IOHIDDevice} fixtures.
+   *
+   * @param discoveredDevices the native devices returned by
+   *                          {@link MacOS#getSupportedHIDDevices(Arena, MemorySegment)}.
+   */
+  void populateDevices(Collection<IOHIDDevice> discoveredDevices) {
+    for (var ioHIDDevice : discoveredDevices) {
+      log.log(Level.FINE, "Found HID device: " + ioHIDDevice.productName);
+      String displayName = ControllerDatabase.getDisplayName(ioHIDDevice.vendorId, ioHIDDevice.productId);
+      var inputDevice = new InputDevice(Long.toString(ioHIDDevice.address), ioHIDDevice.productName, ioHIDDevice.manufacturer + " (" + ioHIDDevice.transport + ")", ioHIDDevice.vendorId, ioHIDDevice.productId, displayName, this::pollIOHIDDevice, this::rumbleIOHIDDevice, this::getBatteryInfo);
+      ioHIDDevice.inputDevice = inputDevice;
+
+      for (var element : ioHIDDevice.getElements()) {
+        if (element.getUsage() == IOHIDElementUsage.UNDEFINED) {
+          continue;
+        }
+
+        var component = new InputComponent(inputDevice, element.getIdentifier(), element.getName());
+        inputDevice.addComponent(component);
+      }
+
+      IOKitVirtualComponentHandler.prepareVirtualComponents(inputDevice, inputDevice.getComponents());
+      nativeDevices.put(inputDevice.getID(), ioHIDDevice);
     }
   }
 

--- a/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/MacOS.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/MacOS.java
@@ -241,46 +241,57 @@ class MacOS {
     try {
       // Copy the set of devices from the HID manager
       var deviceSet = (MemorySegment) IOHIDManagerCopyDevices.invoke(hidManager);
-      var count = (int) CFSetGetCount.invoke(deviceSet);
       if (deviceSet.equals(MemorySegment.NULL)) {
         throw new RuntimeException("Failed to copy devices from HID manager");
       }
 
-      // Allocate memory for the devices
-      var devices = memoryArena.allocate(JAVA_LONG, count);
-      CFSetGetValues.invoke(deviceSet, devices);
-
       var hidDevices = new ArrayList<IOHIDDevice>();
-      for (int i = 0; i < count; i++) {
-        var device = new IOHIDDevice();
-        device.address = devices.get(JAVA_LONG, i * JAVA_LONG.byteSize());
+      try {
+        var count = (int) CFSetGetCount.invoke(deviceSet);
 
-        // Initialize the device and check if it is supported
-        if (!initializeDevice(memoryArena, device)) {
-          continue;
-        }
+        // Allocate memory for the devices
+        var devices = memoryArena.allocate(JAVA_LONG, count);
+        CFSetGetValues.invoke(deviceSet, devices);
 
-        // Copy matching elements for the device
-        var elements = (MemorySegment) IOHIDDeviceCopyMatchingElements.invoke(device.address, MemorySegment.NULL, 0);
-        if (!elements.equals(MemorySegment.NULL)) {
-          var elementCount = (int) CFArrayGetCount.invoke(elements);
-          for (int j = 0; j < elementCount; j++) {
-            var elementAddress = (MemorySegment) CFArrayGetValueAtIndex.invoke(elements, j);
-            if (elementAddress.equals(MemorySegment.NULL)) {
-              continue;
-            }
+        for (int i = 0; i < count; i++) {
+          var device = new IOHIDDevice();
+          device.address = devices.get(JAVA_LONG, i * JAVA_LONG.byteSize());
 
-            // Get the IOHIDElement and add it to the device
-            var element = getIOHIDElement(memoryArena, elementAddress);
-            device.addElement(element);
+          // Initialize the device and check if it is supported
+          if (!initializeDevice(memoryArena, device)) {
+            continue;
           }
+
+          // Copy matching elements for the device
+          var elements = (MemorySegment) IOHIDDeviceCopyMatchingElements.invoke(device.address, MemorySegment.NULL, 0);
+          if (!elements.equals(MemorySegment.NULL)) {
+            try {
+              var elementCount = (int) CFArrayGetCount.invoke(elements);
+              for (int j = 0; j < elementCount; j++) {
+                var elementAddress = (MemorySegment) CFArrayGetValueAtIndex.invoke(elements, j);
+                if (elementAddress.equals(MemorySegment.NULL)) {
+                  continue;
+                }
+
+                // Get the IOHIDElement and add it to the device
+                var element = getIOHIDElement(memoryArena, elementAddress);
+                device.addElement(element);
+              }
+            } finally {
+              // IOHIDDeviceCopyMatchingElements follows the Create Rule: caller owns the +1 retain.
+              CFRelease.invoke(elements);
+            }
+          }
+
+          // Add the device to the list of HID devices
+          hidDevices.add(device);
         }
 
-        // Add the device to the list of HID devices
-        hidDevices.add(device);
+        return hidDevices;
+      } finally {
+        // IOHIDManagerCopyDevices follows the Create Rule: caller owns the +1 retain.
+        CFRelease.invoke(deviceSet);
       }
-
-      return hidDevices;
     } catch (Throwable t) {
       throw new RuntimeException(t);
     }

--- a/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/MacOS.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/MacOS.java
@@ -80,6 +80,7 @@ class MacOS {
   private static final MethodHandle IOHIDValueGetTimeStamp;
 
   private static final MethodHandle IOHIDElementGetName;
+  private static final MethodHandle IOHIDElementGetCookie;
   private static final MethodHandle IOHIDElementGetUsage;
   private static final MethodHandle IOHIDElementGetUsagePage;
   private static final MethodHandle IOHIDElementGetType;
@@ -149,6 +150,7 @@ class MacOS {
     IOHIDValueGetTimeStamp = downcallHandle("IOHIDValueGetTimeStamp", FunctionDescriptor.of(JAVA_LONG, ADDRESS));
 
     IOHIDElementGetName = downcallHandle("IOHIDElementGetName", FunctionDescriptor.of(ADDRESS, JAVA_LONG));
+    IOHIDElementGetCookie = downcallHandle("IOHIDElementGetCookie", FunctionDescriptor.of(JAVA_INT, JAVA_LONG));
     IOHIDElementGetUsage = downcallHandle("IOHIDElementGetUsage", FunctionDescriptor.of(JAVA_INT, JAVA_LONG));
     IOHIDElementGetUsagePage = downcallHandle("IOHIDElementGetUsagePage", FunctionDescriptor.of(JAVA_INT, JAVA_LONG));
     IOHIDElementGetType = downcallHandle("IOHIDElementGetType", FunctionDescriptor.of(JAVA_INT, JAVA_LONG));
@@ -174,6 +176,24 @@ class MacOS {
   static MemorySegment IOHIDValueGetElement(MemorySegment ioHIDValue) {
     try {
       return (MemorySegment) IOHIDValueGetElement.invoke(ioHIDValue);
+    } catch (Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  /**
+   * Retrieves the cookie (a 32-bit identifier unique within a device) of the
+   * given IOHIDElement. The cookie is the stable disambiguation key we use
+   * in the input value callback to map a value back to its element, in
+   * preference to comparing raw {@code IOHIDElementRef} pointers, which can
+   * be confused by FFM address-carrier MemorySegments.
+   *
+   * @param element The IOHIDElement whose cookie to read.
+   * @return The element cookie, or 0 if it could not be read.
+   */
+  static int IOHIDElementGetCookie(MemorySegment element) {
+    try {
+      return (int) IOHIDElementGetCookie.invoke(element.address());
     } catch (Throwable t) {
       throw new RuntimeException(t);
     }
@@ -435,6 +455,7 @@ class MacOS {
   private static IOHIDElement getIOHIDElement(Arena memoryArena, MemorySegment elementAddress) throws Throwable {
     var element = new IOHIDElement();
     element.address = elementAddress.address();
+    element.cookie = (int) IOHIDElementGetCookie.invoke(element.address);
 
     var elementNameRef = (MemorySegment) IOHIDElementGetName.invoke(element.address);
     if (!elementNameRef.equals(MemorySegment.NULL)) {

--- a/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/MacOS.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/MacOS.java
@@ -3,8 +3,10 @@ package de.gurkenlabs.input4j.foreign.macos.iokit;
 import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
 import java.lang.invoke.MethodHandle;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -16,6 +18,12 @@ class MacOS {
 
   private static final int kCFStringEncodingUTF8 = 0x08000100;
   private static final int kCFNumberIntType = 9;
+
+  // HID usage values (kHIDUsage_GD_*) used to narrow the IOHIDManager matching
+  // dictionary to joystick/gamepad/multi-axis controllers.
+  private static final int kHIDUsage_GD_Joystick = 0x04;
+  private static final int kHIDUsage_GD_Gamepad = 0x05;
+  private static final int kHIDPage_GenericDesktop = 0x01;
 
   // IOHID Report Types
   // See: kIOHIDReportType (Apple Developer Documentation)
@@ -33,11 +41,23 @@ class MacOS {
 
   private static final String kCFRunLoopDefaultMode = "kCFRunLoopDefaultMode";
 
+  // CoreFoundation collection/box call-back structs, looked up at static init
+  // time from the CoreFoundation framework so we do not have to depend on
+  // hard-coded addresses that change between macOS releases.
+  private static final MemorySegment kCFTypeDictionaryKeyCallBacks;
+  private static final MemorySegment kCFTypeDictionaryValueCallBacks;
+  private static final MemorySegment kCFTypeArrayCallBacks;
+
   private static final MethodHandle CFRelease;
   private static final MethodHandle CFStringCreateWithCString;
   private static final MethodHandle CFNumberGetValue;
+  private static final MethodHandle CFNumberCreate;
   private static final MethodHandle CFArrayGetCount;
   private static final MethodHandle CFArrayGetValueAtIndex;
+  private static final MethodHandle CFArrayCreateMutable;
+  private static final MethodHandle CFArrayAppendValue;
+  private static final MethodHandle CFDictionaryCreateMutable;
+  private static final MethodHandle CFDictionarySetValue;
   private static final MethodHandle CFSetGetCount;
   private static final MethodHandle CFSetGetValues;
   private static final MethodHandle CFStringGetCString;
@@ -79,13 +99,34 @@ class MacOS {
     System.load("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation");
     System.load("/System/Library/Frameworks/IOKit.framework/IOKit");
 
+    // Look up the CoreFoundation collection/box call-back struct addresses so
+    // we can pass them to CFDictionaryCreateMutable / CFArrayCreateMutable.
+    // These are exported CoreFoundation symbols; their addresses change
+    // between macOS releases, so we resolve them dynamically instead of
+    // hard-coding pointers.
+    try (var lookupArena = Arena.ofConfined()) {
+      var cfLookup = SymbolLookup.libraryLookup(
+          Path.of("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"),
+          lookupArena);
+      kCFTypeDictionaryKeyCallBacks = cfLookup.find("kCFTypeDictionaryKeyCallBacks").orElseThrow();
+      kCFTypeDictionaryValueCallBacks = cfLookup.find("kCFTypeDictionaryValueCallBacks").orElseThrow();
+      kCFTypeArrayCallBacks = cfLookup.find("kCFTypeArrayCallBacks").orElseThrow();
+    }
+
     // CoreFoundation methods
     CFRelease = downcallHandle("CFRelease", FunctionDescriptor.ofVoid(ADDRESS));
     CFStringCreateWithCString = downcallHandle("CFStringCreateWithCString", FunctionDescriptor.of(ADDRESS, ADDRESS, ADDRESS, JAVA_INT));
     CFNumberGetValue = downcallHandle("CFNumberGetValue", FunctionDescriptor.of(JAVA_BOOLEAN, ADDRESS, JAVA_INT, ADDRESS));
-    CFArrayGetCount = downcallHandle("CFArrayGetCount", FunctionDescriptor.of(JAVA_INT, ADDRESS));
-    CFArrayGetValueAtIndex = downcallHandle("CFArrayGetValueAtIndex", FunctionDescriptor.of(ADDRESS, ADDRESS, JAVA_INT));
-    CFSetGetCount = downcallHandle("CFSetGetCount", FunctionDescriptor.of(JAVA_INT, ADDRESS));
+    CFNumberCreate = downcallHandle("CFNumberCreate", FunctionDescriptor.of(ADDRESS, ADDRESS, JAVA_INT, ADDRESS));
+    // CFIndex is long on 64-bit macOS, so the count / index return / arg
+    // layouts must use JAVA_LONG, not JAVA_INT.
+    CFArrayGetCount = downcallHandle("CFArrayGetCount", FunctionDescriptor.of(JAVA_LONG, ADDRESS));
+    CFArrayGetValueAtIndex = downcallHandle("CFArrayGetValueAtIndex", FunctionDescriptor.of(ADDRESS, ADDRESS, JAVA_LONG));
+    CFArrayCreateMutable = downcallHandle("CFArrayCreateMutable", FunctionDescriptor.of(ADDRESS, ADDRESS, JAVA_LONG, ADDRESS));
+    CFArrayAppendValue = downcallHandle("CFArrayAppendValue", FunctionDescriptor.ofVoid(ADDRESS, ADDRESS));
+    CFDictionaryCreateMutable = downcallHandle("CFDictionaryCreateMutable", FunctionDescriptor.of(ADDRESS, ADDRESS, JAVA_LONG, ADDRESS, ADDRESS));
+    CFDictionarySetValue = downcallHandle("CFDictionarySetValue", FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS));
+    CFSetGetCount = downcallHandle("CFSetGetCount", FunctionDescriptor.of(JAVA_LONG, ADDRESS));
     CFSetGetValues = downcallHandle("CFSetGetValues", FunctionDescriptor.ofVoid(ADDRESS, ADDRESS));
     CFStringGetCString = downcallHandle("CFStringGetCString", FunctionDescriptor.of(JAVA_BOOLEAN, ADDRESS, ADDRESS, JAVA_INT, JAVA_INT));
     CFRunLoopGetCurrent = downcallHandle("CFRunLoopGetCurrent", FunctionDescriptor.of(ADDRESS));
@@ -184,11 +225,93 @@ class MacOS {
         throw new RuntimeException("Failed to open HID manager: " + openResult);
       }
 
-      IOHIDManagerSetDeviceMatching.invoke(hidManager, MemorySegment.NULL);
+      // Restrict the HID manager to joystick / gamepad / multi-axis controllers
+      // on the Generic Desktop usage page. Without this, the input value
+      // callback fires for keyboards, mice, trackpads, and any other HID
+      // device on the system, which floods the log and pollutes the
+      // device list. The matching dict is retained by the IOHIDManager so
+      // we release our reference below.
+      var matchingDict = createGamepadMatchingDictionary();
+      try {
+        IOHIDManagerSetDeviceMatching.invoke(hidManager, matchingDict);
+      } finally {
+        CFRelease.invoke(matchingDict);
+      }
+
       IOHIDManagerRegisterInputValueCallback.invoke(hidManager, hidInputValueCallbackPointer, MemorySegment.NULL);
       return hidManager;
     } catch (Throwable t) {
       throw new RuntimeException(t);
+    }
+  }
+
+  /**
+   * Builds a CoreFoundation matching dictionary that restricts the
+   * IOHIDManager to HID devices whose primary usage page is
+   * {@code kHIDPage_GenericDesktop} (0x01) and whose primary usage is one of
+   * joystick, gamepad, or multi-axis controller. The returned
+   * {@link MemorySegment} is a +1 retain owned by the caller.
+   */
+  private static MemorySegment createGamepadMatchingDictionary() {
+    try (var arena = Arena.ofConfined()) {
+      var usagesArray = (MemorySegment) CFArrayCreateMutable.invoke(
+          MemorySegment.NULL, 0L, kCFTypeArrayCallBacks);
+      try {
+        for (int usage : new int[] {kHIDUsage_GD_Joystick, kHIDUsage_GD_Gamepad}) {
+          var usageValue = arena.allocate(JAVA_INT);
+          usageValue.set(JAVA_INT, 0, usage);
+          var usageNumber = (MemorySegment) CFNumberCreate.invoke(
+              MemorySegment.NULL, kCFNumberIntType, usageValue);
+          try {
+            CFArrayAppendValue.invoke(usagesArray, usageNumber);
+          } finally {
+            CFRelease.invoke(usageNumber);
+          }
+        }
+
+        var matchingDict = (MemorySegment) CFDictionaryCreateMutable.invoke(
+            MemorySegment.NULL, 0L, kCFTypeDictionaryKeyCallBacks, kCFTypeDictionaryValueCallBacks);
+        try {
+          putCFDictionaryInt(matchingDict, arena, kIOHIDPrimaryUsagePageKey, kHIDPage_GenericDesktop);
+          putCFDictionaryValue(matchingDict, arena, kIOHIDPrimaryUsageKey, usagesArray);
+          return matchingDict;
+        } catch (Throwable t) {
+          CFRelease.invoke(matchingDict);
+          throw t;
+        }
+      } catch (Throwable t) {
+        CFRelease.invoke(usagesArray);
+        throw t;
+      }
+    } catch (Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  private static void putCFDictionaryInt(MemorySegment dict, Arena arena, String key, int value) throws Throwable {
+    var valueSegment = arena.allocate(JAVA_INT);
+    valueSegment.set(JAVA_INT, 0, value);
+    var number = (MemorySegment) CFNumberCreate.invoke(MemorySegment.NULL, kCFNumberIntType, valueSegment);
+    try {
+      var keyString = (MemorySegment) CFStringCreateWithCString.invoke(
+          MemorySegment.NULL, arena.allocateFrom(key), kCFStringEncodingUTF8);
+      try {
+        CFDictionarySetValue.invoke(dict, keyString, number);
+      } finally {
+        CFRelease.invoke(keyString);
+      }
+    } finally {
+      CFRelease.invoke(number);
+    }
+  }
+
+  private static void putCFDictionaryValue(MemorySegment dict, Arena arena, String key, MemorySegment value) throws Throwable {
+    var keyString = (MemorySegment) CFStringCreateWithCString.invoke(
+        MemorySegment.NULL, arena.allocateFrom(key), kCFStringEncodingUTF8);
+    try {
+      CFDictionarySetValue.invoke(dict, keyString, value);
+    } finally {
+      CFRelease.invoke(keyString);
     }
   }
 
@@ -247,13 +370,13 @@ class MacOS {
 
       var hidDevices = new ArrayList<IOHIDDevice>();
       try {
-        var count = (int) CFSetGetCount.invoke(deviceSet);
+        var count = (long) CFSetGetCount.invoke(deviceSet);
 
         // Allocate memory for the devices
         var devices = memoryArena.allocate(JAVA_LONG, count);
         CFSetGetValues.invoke(deviceSet, devices);
 
-        for (int i = 0; i < count; i++) {
+        for (long i = 0; i < count; i++) {
           var device = new IOHIDDevice();
           device.address = devices.get(JAVA_LONG, i * JAVA_LONG.byteSize());
 
@@ -266,8 +389,8 @@ class MacOS {
           var elements = (MemorySegment) IOHIDDeviceCopyMatchingElements.invoke(device.address, MemorySegment.NULL, 0);
           if (!elements.equals(MemorySegment.NULL)) {
             try {
-              var elementCount = (int) CFArrayGetCount.invoke(elements);
-              for (int j = 0; j < elementCount; j++) {
+              var elementCount = (long) CFArrayGetCount.invoke(elements);
+              for (long j = 0; j < elementCount; j++) {
                 var elementAddress = (MemorySegment) CFArrayGetValueAtIndex.invoke(elements, j);
                 if (elementAddress.equals(MemorySegment.NULL)) {
                   continue;

--- a/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/MacOS.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/MacOS.java
@@ -48,6 +48,17 @@ class MacOS {
   private static final MemorySegment kCFTypeDictionaryValueCallBacks;
   private static final MemorySegment kCFTypeArrayCallBacks;
 
+  /**
+   * Long-lived arena for the CoreFoundation callback-struct lookups performed
+   * in the static initializer below. The three MemorySegments we resolve
+   * (kCFTypeDictionaryKeyCallBacks, kCFTypeDictionaryValueCallBacks,
+   * kCFTypeArrayCallBacks) point at read-only data in the framework binary
+   * that stays loaded for the JVM's lifetime, so we want the segments to be
+   * valid for the same duration. {@code Arena.global()} is multi-thread
+   * safe, has no owner, and is implicitly closed when the JVM exits.
+   */
+  private static final Arena CORE_FOUNDATION_LOOKUP_ARENA = Arena.global();
+
   private static final MethodHandle CFRelease;
   private static final MethodHandle CFStringCreateWithCString;
   private static final MethodHandle CFNumberGetValue;
@@ -104,15 +115,16 @@ class MacOS {
     // we can pass them to CFDictionaryCreateMutable / CFArrayCreateMutable.
     // These are exported CoreFoundation symbols; their addresses change
     // between macOS releases, so we resolve them dynamically instead of
-    // hard-coding pointers.
-    try (var lookupArena = Arena.ofConfined()) {
-      var cfLookup = SymbolLookup.libraryLookup(
-          Path.of("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"),
-          lookupArena);
-      kCFTypeDictionaryKeyCallBacks = cfLookup.find("kCFTypeDictionaryKeyCallBacks").orElseThrow();
-      kCFTypeDictionaryValueCallBacks = cfLookup.find("kCFTypeDictionaryValueCallBacks").orElseThrow();
-      kCFTypeArrayCallBacks = cfLookup.find("kCFTypeArrayCallBacks").orElseThrow();
-    }
+    // hard-coding pointers. The lookups are backed by
+    // {@link #CORE_FOUNDATION_LOOKUP_ARENA} ({@code Arena.global()}) so the
+    // resulting MemorySegments remain valid for the JVM lifetime; a confined
+    // arena would invalidate them as soon as this static block returns.
+    var cfLookup = SymbolLookup.libraryLookup(
+        Path.of("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"),
+        CORE_FOUNDATION_LOOKUP_ARENA);
+    kCFTypeDictionaryKeyCallBacks = cfLookup.find("kCFTypeDictionaryKeyCallBacks").orElseThrow();
+    kCFTypeDictionaryValueCallBacks = cfLookup.find("kCFTypeDictionaryValueCallBacks").orElseThrow();
+    kCFTypeArrayCallBacks = cfLookup.find("kCFTypeArrayCallBacks").orElseThrow();
 
     // CoreFoundation methods
     CFRelease = downcallHandle("CFRelease", FunctionDescriptor.ofVoid(ADDRESS));

--- a/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/MacOS.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/MacOS.java
@@ -23,6 +23,7 @@ class MacOS {
   // dictionary to joystick/gamepad/multi-axis controllers.
   private static final int kHIDUsage_GD_Joystick = 0x04;
   private static final int kHIDUsage_GD_Gamepad = 0x05;
+  private static final int kHIDUsage_GD_MultiAxisController = 0x08;
   private static final int kHIDPage_GenericDesktop = 0x01;
 
   // IOHID Report Types
@@ -58,6 +59,15 @@ class MacOS {
    * safe, has no owner, and is implicitly closed when the JVM exits.
    */
   private static final Arena CORE_FOUNDATION_LOOKUP_ARENA = Arena.global();
+
+  /**
+   * Singleton matching dictionary for the IOHIDManager, restricting the
+   * matched devices to joystick / gamepad / multi-axis controller on the
+   * Generic Desktop usage page. Built once at class init and reused across
+   * {@link #initHIDManager} invocations. The IOHIDManager retains the dict
+   * for as long as it is scheduled, so we never release our +1 reference.
+   */
+  private static final MemorySegment GAMEPAD_MATCHING_DICTIONARY;
 
   private static final MethodHandle CFRelease;
   private static final MethodHandle CFStringCreateWithCString;
@@ -119,12 +129,14 @@ class MacOS {
     // {@link #CORE_FOUNDATION_LOOKUP_ARENA} ({@code Arena.global()}) so the
     // resulting MemorySegments remain valid for the JVM lifetime; a confined
     // arena would invalidate them as soon as this static block returns.
-    var cfLookup = SymbolLookup.libraryLookup(
-        Path.of("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"),
-        CORE_FOUNDATION_LOOKUP_ARENA);
-    kCFTypeDictionaryKeyCallBacks = cfLookup.find("kCFTypeDictionaryKeyCallBacks").orElseThrow();
-    kCFTypeDictionaryValueCallBacks = cfLookup.find("kCFTypeDictionaryValueCallBacks").orElseThrow();
-    kCFTypeArrayCallBacks = cfLookup.find("kCFTypeArrayCallBacks").orElseThrow();
+  var cfLookup = SymbolLookup.libraryLookup(
+      Path.of("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"),
+      CORE_FOUNDATION_LOOKUP_ARENA);
+  kCFTypeDictionaryKeyCallBacks = cfLookup.find("kCFTypeDictionaryKeyCallBacks").orElseThrow();
+  kCFTypeDictionaryValueCallBacks = cfLookup.find("kCFTypeDictionaryValueCallBacks").orElseThrow();
+  kCFTypeArrayCallBacks = cfLookup.find("kCFTypeArrayCallBacks").orElseThrow();
+
+  GAMEPAD_MATCHING_DICTIONARY = createGamepadMatchingDictionary();
 
     // CoreFoundation methods
     CFRelease = downcallHandle("CFRelease", FunctionDescriptor.ofVoid(ADDRESS));
@@ -258,19 +270,7 @@ class MacOS {
         throw new RuntimeException("Failed to open HID manager: " + openResult);
       }
 
-      // Restrict the HID manager to joystick / gamepad / multi-axis controllers
-      // on the Generic Desktop usage page. Without this, the input value
-      // callback fires for keyboards, mice, trackpads, and any other HID
-      // device on the system, which floods the log and pollutes the
-      // device list. The matching dict is retained by the IOHIDManager so
-      // we release our reference below.
-      var matchingDict = createGamepadMatchingDictionary();
-      try {
-        IOHIDManagerSetDeviceMatching.invoke(hidManager, matchingDict);
-      } finally {
-        CFRelease.invoke(matchingDict);
-      }
-
+      IOHIDManagerSetDeviceMatching.invoke(hidManager, GAMEPAD_MATCHING_DICTIONARY);
       IOHIDManagerRegisterInputValueCallback.invoke(hidManager, hidInputValueCallbackPointer, MemorySegment.NULL);
       return hidManager;
     } catch (Throwable t) {
@@ -279,18 +279,16 @@ class MacOS {
   }
 
   /**
-   * Builds a CoreFoundation matching dictionary that restricts the
-   * IOHIDManager to HID devices whose primary usage page is
-   * {@code kHIDPage_GenericDesktop} (0x01) and whose primary usage is one of
-   * joystick, gamepad, or multi-axis controller. The returned
-   * {@link MemorySegment} is a +1 retain owned by the caller.
+   * Builds the singleton {@link #GAMEPAD_MATCHING_DICTIONARY}. See that
+   * field for the matching semantics. The returned {@link MemorySegment}
+   * is a +1 retain owned by the JVM (never released).
    */
   private static MemorySegment createGamepadMatchingDictionary() {
     try (var arena = Arena.ofConfined()) {
       var usagesArray = (MemorySegment) CFArrayCreateMutable.invoke(
           MemorySegment.NULL, 0L, kCFTypeArrayCallBacks);
       try {
-        for (int usage : new int[] {kHIDUsage_GD_Joystick, kHIDUsage_GD_Gamepad}) {
+        for (int usage : new int[] {kHIDUsage_GD_Joystick, kHIDUsage_GD_Gamepad, kHIDUsage_GD_MultiAxisController}) {
           var usageValue = arena.allocate(JAVA_INT);
           usageValue.set(JAVA_INT, 0, usage);
           var usageNumber = (MemorySegment) CFNumberCreate.invoke(

--- a/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/MacOS.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/MacOS.java
@@ -84,6 +84,7 @@ class MacOS {
   private static final MethodHandle CFStringGetCString;
   private static final MethodHandle CFRunLoopGetCurrent;
   private static final MethodHandle CFRunLoopRun;
+  private static final MethodHandle CFRunLoopStop;
 
   private static final MethodHandle IOHIDManagerCreate;
   private static final MethodHandle IOHIDManagerOpen;
@@ -156,6 +157,7 @@ class MacOS {
     CFStringGetCString = downcallHandle("CFStringGetCString", FunctionDescriptor.of(JAVA_BOOLEAN, ADDRESS, ADDRESS, JAVA_INT, JAVA_INT));
     CFRunLoopGetCurrent = downcallHandle("CFRunLoopGetCurrent", FunctionDescriptor.of(ADDRESS));
     CFRunLoopRun = downcallHandle("CFRunLoopRun", FunctionDescriptor.ofVoid());
+    CFRunLoopStop = downcallHandle("CFRunLoopStop", FunctionDescriptor.ofVoid(ADDRESS));
 
     // IOKit methods
     IOHIDManagerCreate = downcallHandle("IOHIDManagerCreate", FunctionDescriptor.of(ADDRESS, ADDRESS, JAVA_INT));
@@ -378,6 +380,32 @@ class MacOS {
       }
 
       CFRunLoopRun.invoke();
+    } catch (Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  /**
+   * Returns the {@code CFRunLoopRef} for the calling thread. Used by
+   * {@link IOKitPlugin} to capture the event-loop thread's run loop so
+   * {@link #CFRunLoopStop(MemorySegment)} can later wake it.
+   */
+  static MemorySegment CFRunLoopGetCurrent() {
+    try {
+      return (MemorySegment) CFRunLoopGetCurrent.invoke();
+    } catch (Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  /**
+   * Forces a run loop to stop. {@code CFRunLoopRun} checks this flag at
+   * the top of each iteration; an in-flight callback is allowed to
+   * complete first.
+   */
+  static void CFRunLoopStop(MemorySegment runLoop) {
+    try {
+      CFRunLoopStop.invoke(runLoop);
     } catch (Throwable t) {
       throw new RuntimeException(t);
     }

--- a/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/MacOS.java
+++ b/src/main/java/de/gurkenlabs/input4j/foreign/macos/iokit/MacOS.java
@@ -201,7 +201,8 @@ class MacOS {
    * be confused by FFM address-carrier MemorySegments.
    *
    * @param element The IOHIDElement whose cookie to read.
-   * @return The element cookie, or 0 if it could not be read.
+   * @return The element cookie.
+   * @throws RuntimeException if the underlying FFM call fails.
    */
   static int IOHIDElementGetCookie(MemorySegment element) {
     try {

--- a/src/test/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPluginTests.java
+++ b/src/test/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPluginTests.java
@@ -142,14 +142,13 @@ public class IOKitPluginTests {
   }
 
   @Test
-  void testPopulateDevices_registersDevicesAndComponents() throws Exception {
+  void testPopulateDevices_registersDevicesAndComponents() {
     var plugin = new IOKitPlugin();
     var button = makeElement(0x10, 0xAAAA0001L, IOHIDElementUsage.BUTTON_1, IOHIDElementType.BUTTON);
     var axis = makeElement(0x20, 0xAAAA0002L, IOHIDElementUsage.X, IOHIDElementType.AXIS);
     var device = makeDevice(0x1234L, 0x046D, 0xC21D, button, axis);
 
     plugin.populateDevices(List.of(device));
-    publishDevices(plugin);
 
     var all = plugin.getAll();
     assertEquals(1, all.size());
@@ -162,14 +161,13 @@ public class IOKitPluginTests {
   }
 
   @Test
-  void testPopulateDevices_skipsUndefinedElements() throws Exception {
+  void testPopulateDevices_skipsUndefinedElements() {
     var plugin = new IOKitPlugin();
     var defined = makeElement(0x10, 0x1L, IOHIDElementUsage.BUTTON_1, IOHIDElementType.BUTTON);
     var undefined = makeElement(0x11, 0x2L, IOHIDElementUsage.UNDEFINED, IOHIDElementType.MISC);
     var device = makeDevice(0xCAFE, 0x1234, 0x5678, defined, undefined);
 
     plugin.populateDevices(List.of(device));
-    publishDevices(plugin);
 
     // Even though the UNDEFINED element is skipped for components, it must
     // still be added to the cookie index so the input value callback can
@@ -213,7 +211,7 @@ public class IOKitPluginTests {
   }
 
   @Test
-  void testFindElement_isolatesCookiesAcrossDevices() throws Exception {
+  void testFindElement_isolatesCookiesAcrossDevices() {
     var plugin = new IOKitPlugin();
     // Two devices, each with an element that happens to share a cookie
     // value. The lookup must distinguish them by device address.
@@ -248,18 +246,5 @@ public class IOKitPluginTests {
     @SuppressWarnings("unchecked")
     Map<String, IOHIDDevice> nativeDevices = (Map<String, IOHIDDevice>) nativeDevicesField.get(plugin);
     assertTrue(nativeDevices.isEmpty());
-  }
-
-  /** Mirrors the setDevices call done in {@code internalInitDevices} so the tests can exercise {@code getAll}. */
-  private static void publishDevices(IOKitPlugin plugin) throws Exception {
-    Field nativeDevicesField = IOKitPlugin.class.getDeclaredField("nativeDevices");
-    nativeDevicesField.setAccessible(true);
-    @SuppressWarnings("unchecked")
-    Map<String, IOHIDDevice> nativeDevices = (Map<String, IOHIDDevice>) nativeDevicesField.get(plugin);
-    var inputDevices = nativeDevices.values().stream().map(d -> d.inputDevice).toList();
-    var setDevices = Class.forName("de.gurkenlabs.input4j.AbstractInputDevicePlugin")
-        .getDeclaredMethod("setDevices", java.util.Collection.class);
-    setDevices.setAccessible(true);
-    setDevices.invoke(plugin, inputDevices);
   }
 }

--- a/src/test/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPluginTests.java
+++ b/src/test/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPluginTests.java
@@ -1,12 +1,13 @@
 package de.gurkenlabs.input4j.foreign.macos.iokit;
 
-import de.gurkenlabs.input4j.InputComponent;
-import de.gurkenlabs.input4j.InputDevice;
-import org.junit.jupiter.api.Test;
-
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import de.gurkenlabs.input4j.InputComponent;
+import de.gurkenlabs.input4j.InputDevice;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPluginTests.java
+++ b/src/test/java/de/gurkenlabs/input4j/foreign/macos/iokit/IOKitPluginTests.java
@@ -1,6 +1,12 @@
 package de.gurkenlabs.input4j.foreign.macos.iokit;
 
+import de.gurkenlabs.input4j.InputComponent;
+import de.gurkenlabs.input4j.InputDevice;
 import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -105,5 +111,155 @@ public class IOKitPluginTests {
     assertFalse(IOKitPlugin.shouldStopRumble(new float[] {0.01f}));
     assertFalse(IOKitPlugin.shouldStopRumble(new float[] {0.5f}));
     assertFalse(IOKitPlugin.shouldStopRumble(new float[] {1.0f}));
+  }
+
+  // --- populateDevices + cookie-based lookup tests -------------------------
+
+  private static IOHIDElement makeElement(int cookie, long address, IOHIDElementUsage usage, IOHIDElementType type) {
+    var element = new IOHIDElement();
+    element.cookie = cookie;
+    element.address = address;
+    element.usage = usage;
+    element.type = type;
+    element.name = "element-" + cookie;
+    return element;
+  }
+
+  private static IOHIDDevice makeDevice(long address, int vendorId, int productId, IOHIDElement... elements) {
+    var device = new IOHIDDevice();
+    device.address = address;
+    device.vendorId = vendorId;
+    device.productId = productId;
+    device.productName = "Device " + address;
+    device.manufacturer = "TestCo";
+    device.transport = "USB";
+    device.usage = 0x05; // gamepad
+    device.usagePage = 0x01; // generic desktop
+    for (var element : elements) {
+      device.addElement(element);
+    }
+    return device;
+  }
+
+  @Test
+  void testPopulateDevices_registersDevicesAndComponents() throws Exception {
+    var plugin = new IOKitPlugin();
+    var button = makeElement(0x10, 0xAAAA0001L, IOHIDElementUsage.BUTTON_1, IOHIDElementType.BUTTON);
+    var axis = makeElement(0x20, 0xAAAA0002L, IOHIDElementUsage.X, IOHIDElementType.AXIS);
+    var device = makeDevice(0x1234L, 0x046D, 0xC21D, button, axis);
+
+    plugin.populateDevices(List.of(device));
+    publishDevices(plugin);
+
+    var all = plugin.getAll();
+    assertEquals(1, all.size());
+    InputDevice registered = all.iterator().next();
+    assertEquals("4660", registered.getID());
+    assertEquals(0x046D, registered.getVendorId());
+    assertEquals(0xC21D, registered.getProductId());
+    // Two non-UNDEFINED elements get a component each.
+    assertEquals(2, registered.getComponents().size());
+  }
+
+  @Test
+  void testPopulateDevices_skipsUndefinedElements() throws Exception {
+    var plugin = new IOKitPlugin();
+    var defined = makeElement(0x10, 0x1L, IOHIDElementUsage.BUTTON_1, IOHIDElementType.BUTTON);
+    var undefined = makeElement(0x11, 0x2L, IOHIDElementUsage.UNDEFINED, IOHIDElementType.MISC);
+    var device = makeDevice(0xCAFE, 0x1234, 0x5678, defined, undefined);
+
+    plugin.populateDevices(List.of(device));
+    publishDevices(plugin);
+
+    // Even though the UNDEFINED element is skipped for components, it must
+    // still be added to the cookie index so the input value callback can
+    // resolve values that arrive against it.
+    InputDevice registered = plugin.getAll().iterator().next();
+    assertEquals(1, registered.getComponents().size());
+    assertNotNull(plugin.findElement(0xCAFEL, 0x10));
+    assertNotNull(plugin.findElement(0xCAFEL, 0x11));
+  }
+
+  @Test
+  void testFindElement_resolvesByCookieAndDevice() {
+    var plugin = new IOKitPlugin();
+    var button = makeElement(0x42, 0xDEADBEEFL, IOHIDElementUsage.BUTTON_1, IOHIDElementType.BUTTON);
+    var device = makeDevice(0x9999L, 0x046D, 0xC21D, button);
+    plugin.populateDevices(List.of(device));
+
+    var found = plugin.findElement(0x9999L, 0x42);
+    assertNotNull(found);
+    assertEquals(0x42, found.cookie);
+  }
+
+  @Test
+  void testFindElement_returnsNullForUnknownCookie() {
+    var plugin = new IOKitPlugin();
+    var button = makeElement(0x42, 0xDEADBEEFL, IOHIDElementUsage.BUTTON_1, IOHIDElementType.BUTTON);
+    var device = makeDevice(0x9999L, 0x046D, 0xC21D, button);
+    plugin.populateDevices(List.of(device));
+
+    assertNull(plugin.findElement(0x9999L, 0x99));
+  }
+
+  @Test
+  void testFindElement_returnsNullForUnknownDevice() {
+    var plugin = new IOKitPlugin();
+    var button = makeElement(0x42, 0xDEADBEEFL, IOHIDElementUsage.BUTTON_1, IOHIDElementType.BUTTON);
+    var device = makeDevice(0x9999L, 0x046D, 0xC21D, button);
+    plugin.populateDevices(List.of(device));
+
+    assertNull(plugin.findElement(0xDEADL, 0x42));
+  }
+
+  @Test
+  void testFindElement_isolatesCookiesAcrossDevices() throws Exception {
+    var plugin = new IOKitPlugin();
+    // Two devices, each with an element that happens to share a cookie
+    // value. The lookup must distinguish them by device address.
+    var leftButton = makeElement(0x10, 0x1L, IOHIDElementUsage.BUTTON_1, IOHIDElementType.BUTTON);
+    var rightButton = makeElement(0x10, 0x2L, IOHIDElementUsage.BUTTON_1, IOHIDElementType.BUTTON);
+    var deviceA = makeDevice(0xAA00L, 0x1, 0x1, leftButton);
+    var deviceB = makeDevice(0xBB00L, 0x2, 0x2, rightButton);
+    plugin.populateDevices(List.of(deviceA, deviceB));
+
+    var resolvedA = plugin.findElement(0xAA00L, 0x10);
+    var resolvedB = plugin.findElement(0xBB00L, 0x10);
+    assertNotNull(resolvedA);
+    assertNotNull(resolvedB);
+    // Different underlying IOHIDElement instances.
+    assertNotSame(resolvedA, resolvedB);
+  }
+
+  @Test
+  void testPopulateDevices_clearsCookieIndexOnClose() throws Exception {
+    var plugin = new IOKitPlugin();
+    var button = makeElement(0x42, 0xDEADBEEFL, IOHIDElementUsage.BUTTON_1, IOHIDElementType.BUTTON);
+    var device = makeDevice(0x9999L, 0x046D, 0xC21D, button);
+    plugin.populateDevices(List.of(device));
+    assertNotNull(plugin.findElement(0x9999L, 0x42));
+
+    plugin.close();
+
+    assertNull(plugin.findElement(0x9999L, 0x42));
+    // nativeDevices cleared too.
+    Field nativeDevicesField = IOKitPlugin.class.getDeclaredField("nativeDevices");
+    nativeDevicesField.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Map<String, IOHIDDevice> nativeDevices = (Map<String, IOHIDDevice>) nativeDevicesField.get(plugin);
+    assertTrue(nativeDevices.isEmpty());
+  }
+
+  /** Mirrors the setDevices call done in {@code internalInitDevices} so the tests can exercise {@code getAll}. */
+  private static void publishDevices(IOKitPlugin plugin) throws Exception {
+    Field nativeDevicesField = IOKitPlugin.class.getDeclaredField("nativeDevices");
+    nativeDevicesField.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Map<String, IOHIDDevice> nativeDevices = (Map<String, IOHIDDevice>) nativeDevicesField.get(plugin);
+    var inputDevices = nativeDevices.values().stream().map(d -> d.inputDevice).toList();
+    var setDevices = Class.forName("de.gurkenlabs.input4j.AbstractInputDevicePlugin")
+        .getDeclaredMethod("setDevices", java.util.Collection.class);
+    setDevices.setAccessible(true);
+    setDevices.invoke(plugin, inputDevices);
   }
 }


### PR DESCRIPTION
## Summary
Fixes #57: macOS IOKit plugin throws `IllegalStateException` and floods log with "IOHIDElement not found" warnings.
## Root cause
1. `setDevices(...)` was called *after* `CFRunLoopRun()` blocked, so callers of `init()` could observe `IllegalStateException` from `getAll()`.
2. The input value callback identified elements by raw `IOHIDElementRef` pointer, which is unreliable when the FFM downcall layer hands back a `MemorySegment` carrier — causing the WARNING flood.
3. The IOHIDManager was matching *all* HID devices (keyboards, mice, trackpads), not just gamepads.
## Changes
- **Async init**: replace `volatile boolean` + `Thread.sleep(100)` polling with `CountDownLatch`; count down in `catch` so failures don't hang.
- **Cookie-based lookup**: bind `IOHIDElementGetCookie`, store on `IOHIDElement`, resolve values via `(deviceAddress, cookie)` index in `hidInputValueCallback`. Demote unknown-element log to FINE.
- **Match gamepad/joystick only**: build a CFDictionary restricting `kIOHIDPrimaryUsagePage` to `0x01` and `kIOHIDPrimaryUsage` to `[joystick, gamepad, multi-axis controller]`.
- **Fix CFIndex width**: `CFArrayGetCount` / `CFSetGetCount` / `CFArrayGetValueAtIndex` use `JAVA_LONG`, not `JAVA_INT`.
- **Resource hygiene**: `CFRelease` the `IOHIDManagerCopyDevices` set and the per-device `IOHIDDeviceCopyMatchingElements` array.
- **FFM lifetime safety**: replace confined `Arena` (closed at end of static block) with `Arena.global()` for the CoreFoundation callback-struct lookups, so the stored `MemorySegment`s live for the JVM lifetime.
- **Graceful shutdown**: `close()` now calls `CFRunLoopStop` on the captured run loop, joins the event-loop thread (3 s timeout), then `super.close()` — no more JVM hangs on a blocked `CFRunLoopRun`.
- **Refactor**: extract package-private `populateDevices(...)` for cross-platform unit testing; fold `setDevices` into it. Singleton-ify the matching dict. `initLatch` → local.
- **Thread-safety**: `IOHIDElement.currentValue` is now `volatile` (was a JLS 17.4 data race between CFRunLoop writer and polling reader).