### PR TITLE
fix: remove sonatype snapshots repo causing 504 and blocking dependen…

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,6 @@ pluginManagement {
 dependencyResolutionManagement {
   repositories {
     mavenLocal()
-    maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots/") }
     mavenCentral()
   }
 }


### PR DESCRIPTION
`oss.sonatype.org` is returning 504 Gateway Timeout. Because this repo is listed before `mavenCentral()` in `settings.gradle`, Gradle hits the timeout before reaching Maven Central for transitive deps (like `org.junit:junit-bom`), failing all builds.

Removed it — no dependency in this project needs Sonatype snapshots.